### PR TITLE
fix(menus): Dropdown and kebab menus are broken

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -18,9 +18,7 @@ import {DummyService} from "./dummy/dummy.service";
 import {ContextService} from "./shared/context.service";
 import {Logger} from "./shared/logger.service";
 import {LocalStorageModule} from 'angular-2-local-storage';
-//import {DropdownModule} from 'ng2-dropdown';
-//import {DropdownModule} from "./shared-component/dropdown/dropdown.module";
-import {DropdownModule} from "ngx-dropdown";
+import {DropdownConfig, DropdownModule} from "ng2-bootstrap";
 import { OAuthService } from 'angular2-oauth2/oauth-service';
 import {OnLogin} from "./shared/onlogin.service";
 
@@ -62,6 +60,7 @@ export function restangularProviderConfigurer(restangularProvider: any, config: 
   ],
   providers: [
     ConfigService,
+    DropdownConfig,
     {
       provide: APP_INITIALIZER,
       useFactory: configServiceInitializer,

--- a/src/app/header/header.component.html
+++ b/src/app/header/header.component.html
@@ -4,8 +4,8 @@
       <li *ngIf="!loggedIn">
         <a (click)='login();'>Sign In</a>
       </li>
-      <li *ngIf="loggedIn" dropdown class="pull-right dropdown">
-        <a dropdown-open class="pull-right">
+      <li *ngIf="loggedIn" class="pull-right" dropdown>
+        <a class="pull-right" dropdownToggle>
           <div *ngIf="loggedInUser" id="header_dropdownToggle_header">
             <span class="nav-item-icon">
               <span *ngIf="!imgLoaded" class="nav-icon pficon-user"></span>
@@ -15,7 +15,7 @@
             <span class="nav-icon caret"></span>
           </div>
         </a>
-        <ul class="dropdown-menu view-width-100">
+        <ul class="view-width-100" role="menu" dropdownMenu>
           <li>
             <a [routerLink]="[urlFeatureToggle + '/pmuir']">
               <span class="nav-item-text">Profile</span>
@@ -44,8 +44,8 @@
   <div class="collapse navbar-collapse navbar-collapse-1">
     <ul class="nav navbar-nav navbar-primary persistent-secondary navbar-left">
       <!-- This part of the menu is dynamic based on context -->
-      <li class="context dropdown" dropdown>
-        <a dropdown-open>
+      <li class="context" dropdown>
+        <a dropdownToggle>
           <div *ngIf="loggedInUser" id="header_dropdownToggle">
             <span *ngIf="dummy.currentContext.type" class="nav-item-icon">
               <span class="nav-icon {{dummy.currentContext.type.icon}}"></span>
@@ -56,7 +56,7 @@
             </span>
           </div>
         </a>
-        <ul class="dropdown-menu">
+        <ul role="menu" dropdownMenu>
           <li>
             <a [routerLink]="['/run/spaces']" title="Browse all spaces">browse spaces</a>
           </li>
@@ -108,8 +108,8 @@
       <li>
         <a *ngIf="!loggedIn" (click)='login();'>Sign In</a>
       </li>
-      <li *ngIf="loggedIn" dropdown class="pull-right dropdown">
-        <a dropdown-open>
+      <li *ngIf="loggedIn" class="pull-right" dropdown>
+        <a dropdownToggle>
           <div *ngIf="loggedInUser" id="header_dropdownToggle2">
             <span class="nav-item-icon">
               <span *ngIf="!imgLoaded" class="nav-icon pficon-user"></span>
@@ -121,7 +121,7 @@
             </span>
           </div>
         </a>
-        <ul class="dropdown-menu">
+        <ul role="menu" dropdownMenu>
           <li>
             <a [routerLink]="[urlFeatureToggle + '/pmuir']"><span class="nav-item-text">Profile</span> </a>
           </li>

--- a/src/app/kubernetes/components/components.module.ts
+++ b/src/app/kubernetes/components/components.module.ts
@@ -1,4 +1,5 @@
 import {NgModule} from "@angular/core";
+import {DropdownConfig, DropdownModule} from "ng2-bootstrap";
 import {PodPhaseIconComponent} from "./pod-phase-icon/pod-phase-icon.component";
 import {KubernetesLabelsComponent} from "./k8s-labels/k8s-labels.component";
 import {Fabric8CommonModule} from "../../common/common.module";
@@ -9,6 +10,7 @@ import {BuildStatusIconComponent} from "./build-status-icon/build-status-icon.co
 @NgModule({
   imports: [
     CommonModule,
+    DropdownModule,
     Fabric8CommonModule,
   ],
   declarations: [
@@ -23,6 +25,9 @@ import {BuildStatusIconComponent} from "./build-status-icon/build-status-icon.co
     PodPhaseIconComponent,
     PipelineStatusComponent,
   ],
+  providers: [
+    DropdownConfig
+  ]
 })
 export class KubernetesComponentsModule {
 }

--- a/src/app/kubernetes/components/resource-header/resource.header.component.html
+++ b/src/app/kubernetes/components/resource-header/resource.header.component.html
@@ -1,11 +1,9 @@
-<li class="context dropdown" dropdown>
-  <button class="btn btn-default dropdown-toggle" dropdown-open>
-          <span>
-            <span class="{{current?.icon}}"></span> {{current?.name}}
-          </span>
-          <b class="caret"></b>
-        </button>
-  <ul class="dropdown-menu">
+<li class='context' dropdown>
+  <button type='button' class='btn btn-default' aria-haspopup='true' aria-expanded='false' dropdownToggle>
+    {{current?.name}}
+    <span class='caret'></span>
+  </button>
+  <ul role="menu" dropdownMenu>
     <li *ngFor="let m of menus">
       <a [routerLink]="[m.fullPath || m.path]" *ngIf="m.path !== null && m != current?.path">
         <span class="{{m.icon}}"></span> {{m.name}}

--- a/src/app/kubernetes/ui/build/build.module.ts
+++ b/src/app/kubernetes/ui/build/build.module.ts
@@ -1,5 +1,6 @@
 import {NgModule} from "@angular/core";
 import {CommonModule} from "@angular/common";
+import {DropdownConfig, DropdownModule} from "ng2-bootstrap";
 import {FormsModule} from "@angular/forms";
 import {RouterModule, Routes} from "@angular/router";
 import {ModalModule} from "ng2-modal";
@@ -28,6 +29,7 @@ const routes: Routes = [
 @NgModule({
   imports: [
     CommonModule,
+    DropdownModule,
     FormsModule,
     ModalModule,
     MomentModule,
@@ -56,6 +58,9 @@ const routes: Routes = [
   exports: [
     ModalModule,
   ],
+  providers: [
+    DropdownConfig
+  ]
 })
 export class BuildModule {
 }

--- a/src/app/kubernetes/ui/build/list-toolbar/list-toolbar.build.component.html
+++ b/src/app/kubernetes/ui/build/list-toolbar/list-toolbar.build.component.html
@@ -12,12 +12,11 @@
       <div class='form-group toolbar-pf-filter search'>
         <label class='sr-only'>Name</label>
         <div class='input-group'>
-          <div class='input-group-btn'>
-            <button type='button' class='btn btn-default dropdown-toggle' data-toggle='dropdown' aria-haspopup='true'
-                    aria-expanded='false'>Name&nbsp;
+          <div class='input-group-btn' dropdown>
+            <button type='button' class='btn btn-default' aria-haspopup='true' aria-expanded='false' dropdownToggle>Name&nbsp;
               <span class='caret'></span>
             </button>
-            <ul class='dropdown-menu'>
+            <ul role="menu" dropdownMenu>
               <li>
                 <a href='#'>Name</a>
               </li>
@@ -33,12 +32,11 @@
       <!-- Toolbar: Sort -->
 
       <div class='form-group sort'>
-        <div class='dropdown btn-group'>
-          <button type='button' class='btn btn-default dropdown-toggle' data-toggle='dropdown' aria-haspopup='true'
-                  aria-expanded='false'>Name&nbsp;
+        <div class='btn-group' dropdown>
+          <button type='button' class='btn btn-default' aria-haspopup='true' aria-expanded='false' dropdownToggle>Name&nbsp;
             <span class='caret'></span>
           </button>
-          <ul class='dropdown-menu'>
+          <ul role="menu" dropdownMenu>
             <li>
               <a href='#'>Name</a>
             </li>

--- a/src/app/kubernetes/ui/build/list/list.build.component.html
+++ b/src/app/kubernetes/ui/build/list/list.build.component.html
@@ -6,11 +6,11 @@
         <input type='checkbox'>
       </div>
       <div class='list-view-pf-actions'>
-        <div class='dropdown pull-right dropdown-kebab-pf'>
-          <button class='btn btn-link dropdown-toggle' type='button' id='dropdownKebabRight9' data-toggle='dropdown' aria-haspopup='true' aria-expanded='true'>
+        <div class='pull-right dropdown-kebab-pf' dropdown>
+          <button class='btn btn-link' type='button' id='dropdownKebabRight9' aria-haspopup='true' aria-expanded='true' dropdownToggle>
               <span class='fa fa-ellipsis-v'></span>
             </button>
-          <ul class='dropdown-menu dropdown-menu-right' aria-labelledby='dropdownKebabRight9'>
+          <ul class='dropdown-menu-right' aria-labelledby='dropdownKebabRight9' role="menu" dropdownMenu>
             <li>
               <a [routerLink]="[build.id, 'edit']">Edit</a>
             </li>

--- a/src/app/kubernetes/ui/buildconfig/buildconfig.module.ts
+++ b/src/app/kubernetes/ui/buildconfig/buildconfig.module.ts
@@ -1,5 +1,6 @@
 import {NgModule} from "@angular/core";
 import {CommonModule} from "@angular/common";
+import {DropdownConfig, DropdownModule} from "ng2-bootstrap";
 import {FormsModule} from "@angular/forms";
 import {RouterModule, Routes} from "@angular/router";
 import {ModalModule} from "ng2-modal";
@@ -29,6 +30,7 @@ const routes: Routes = [
 @NgModule({
   imports: [
     CommonModule,
+    DropdownModule,
     FormsModule,
     ModalModule,
     MomentModule,
@@ -53,6 +55,9 @@ const routes: Routes = [
   entryComponents: [
     BuildConfigEditPage,
   ],
+  providers: [
+    DropdownConfig
+  ]
 })
 export class BuildConfigModule {
 }

--- a/src/app/kubernetes/ui/buildconfig/list-toolbar/list-toolbar.buildconfig.component.html
+++ b/src/app/kubernetes/ui/buildconfig/list-toolbar/list-toolbar.buildconfig.component.html
@@ -12,12 +12,11 @@
       <div class='form-group toolbar-pf-filter search'>
         <label class='sr-only'>Name</label>
         <div class='input-group'>
-          <div class='input-group-btn'>
-            <button type='button' class='btn btn-default dropdown-toggle' data-toggle='dropdown' aria-haspopup='true'
-                    aria-expanded='false'>Name&nbsp;
+          <div class='input-group-btn' dropdown>
+            <button type='button' class='btn btn-default' aria-haspopup='true' aria-expanded='false' dropdownToggle>Name&nbsp;
               <span class='caret'></span>
             </button>
-            <ul class='dropdown-menu'>
+            <ul role="menu" dropdownMenu>
               <li>
                 <a href='#'>Name</a>
               </li>
@@ -33,12 +32,11 @@
       <!-- Toolbar: Sort -->
 
       <div class='form-group sort'>
-        <div class='dropdown btn-group'>
-          <button type='button' class='btn btn-default dropdown-toggle' data-toggle='dropdown' aria-haspopup='true'
-                  aria-expanded='false'>Name&nbsp;
+        <div class='btn-group' dropdown>
+          <button type='button' class='btn btn-default' aria-haspopup='true' aria-expanded='false' dropdownToggle>Name&nbsp;
             <span class='caret'></span>
           </button>
-          <ul class='dropdown-menu'>
+          <ul role="menu" dropdownMenu>
             <li>
               <a href='#'>Name</a>
             </li>

--- a/src/app/kubernetes/ui/buildconfig/list/list.buildconfig.component.html
+++ b/src/app/kubernetes/ui/buildconfig/list/list.buildconfig.component.html
@@ -6,11 +6,11 @@
         <input type='checkbox'>
       </div>
       <div class='list-view-pf-actions'>
-        <div class='dropdown pull-right dropdown-kebab-pf'>
-          <button class='btn btn-link dropdown-toggle' type='button' id='dropdownKebabRight9' data-toggle='dropdown' aria-haspopup='true' aria-expanded='true'>
+        <div class='pull-right dropdown-kebab-pf' dropdown>
+          <button class='btn btn-link' type='button' id='dropdownKebabRight9' aria-haspopup='true' aria-expanded='true' dropdownToggle>
               <span class='fa fa-ellipsis-v'></span>
             </button>
-          <ul class='dropdown-menu dropdown-menu-right' aria-labelledby='dropdownKebabRight9'>
+          <ul class='dropdown-menu-right' aria-labelledby='dropdownKebabRight9' role="menu" dropdownMenu>
             <li *ngIf="buildconfig.lastBuildPath">
               <a routerLink="{{buildconfig.lastBuildPath}}"  title="view last build">
                 View last build

--- a/src/app/kubernetes/ui/configmap/configmap.module.ts
+++ b/src/app/kubernetes/ui/configmap/configmap.module.ts
@@ -1,5 +1,6 @@
 import {NgModule} from "@angular/core";
 import {CommonModule} from "@angular/common";
+import {DropdownConfig, DropdownModule} from "ng2-bootstrap";
 import {FormsModule} from "@angular/forms";
 import {RouterModule, Routes} from "@angular/router";
 import {ModalModule} from "ng2-modal";
@@ -28,6 +29,7 @@ const routes: Routes = [
 @NgModule({
   imports: [
     CommonModule,
+    DropdownModule,
     FormsModule,
     ModalModule,
     MomentModule,
@@ -56,6 +58,9 @@ const routes: Routes = [
   exports: [
     ModalModule,
   ],
+  providers: [
+    DropdownConfig
+  ]
 })
 export class ConfigMapModule {
 }

--- a/src/app/kubernetes/ui/configmap/list-toolbar/list-toolbar.configmap.component.html
+++ b/src/app/kubernetes/ui/configmap/list-toolbar/list-toolbar.configmap.component.html
@@ -10,12 +10,11 @@
       <div class='form-group toolbar-pf-filter search'>
         <label class='sr-only'>Name</label>
         <div class='input-group'>
-          <div class='input-group-btn'>
-            <button type='button' class='btn btn-default dropdown-toggle' data-toggle='dropdown' aria-haspopup='true'
-                    aria-expanded='false'>Name&nbsp;
+          <div class='input-group-btn' dropdown>
+            <button type='button' class='btn btn-default' aria-haspopup='true' aria-expanded='false' dropdownToggle>Name&nbsp;
               <span class='caret'></span>
             </button>
-            <ul class='dropdown-menu'>
+            <ul role="menu" dropdownMenu>
               <li>
                 <a href='#'>Name</a>
               </li>
@@ -31,12 +30,11 @@
       <!-- Toolbar: Sort -->
 
       <div class='form-group sort'>
-        <div class='dropdown btn-group'>
-          <button type='button' class='btn btn-default dropdown-toggle' data-toggle='dropdown' aria-haspopup='true'
-                  aria-expanded='false'>Name&nbsp;
+        <div class='btn-group' dropdown>
+          <button type='button' class='btn btn-default' aria-haspopup='true' aria-expanded='false' dropdownToggle>Name&nbsp;
             <span class='caret'></span>
           </button>
-          <ul class='dropdown-menu'>
+          <ul role="menu" dropdownMenu>
             <li>
               <a href='#'>Name</a>
             </li>

--- a/src/app/kubernetes/ui/configmap/list/list.configmap.component.html
+++ b/src/app/kubernetes/ui/configmap/list/list.configmap.component.html
@@ -6,11 +6,11 @@
         <input type='checkbox'>
       </div>
       <div class='list-view-pf-actions'>
-        <div class='dropdown pull-right dropdown-kebab-pf'>
-          <button class='btn btn-link dropdown-toggle' type='button' id='dropdownKebabRight9' data-toggle='dropdown' aria-haspopup='true' aria-expanded='true'>
+        <div class='pull-right dropdown-kebab-pf' dropdown>
+          <button class='btn btn-link' type='button' id='dropdownKebabRight9' aria-haspopup='true' aria-expanded='true' dropdownToggle>
               <span class='fa fa-ellipsis-v'></span>
             </button>
-          <ul class='dropdown-menu dropdown-menu-right' aria-labelledby='dropdownKebabRight9'>
+          <ul class='dropdown-menu-right' aria-labelledby='dropdownKebabRight9' role="menu" dropdownMenu>
             <li>
               <a [routerLink]="[configmap.id, 'edit']">Edit</a>
             </li>

--- a/src/app/kubernetes/ui/deployment/deployment.module.ts
+++ b/src/app/kubernetes/ui/deployment/deployment.module.ts
@@ -1,5 +1,6 @@
 import {NgModule} from "@angular/core";
 import {CommonModule} from "@angular/common";
+import {DropdownConfig, DropdownModule} from "ng2-bootstrap";
 import {FormsModule} from "@angular/forms";
 import {RouterModule, Routes} from "@angular/router";
 import {ModalModule} from "ng2-modal";
@@ -29,6 +30,7 @@ const routes: Routes = [
 @NgModule({
   imports: [
     CommonModule,
+    DropdownModule,
     FormsModule,
     ModalModule,
     MomentModule,
@@ -58,6 +60,9 @@ const routes: Routes = [
   exports: [
     ModalModule,
   ],
+  providers: [
+    DropdownConfig
+  ]
 })
 export class DeploymentModule {
 }

--- a/src/app/kubernetes/ui/deployment/list-toolbar/list-toolbar.deployment.component.html
+++ b/src/app/kubernetes/ui/deployment/list-toolbar/list-toolbar.deployment.component.html
@@ -10,12 +10,11 @@
       <div class='form-group toolbar-pf-filter search'>
         <label class='sr-only'>Name</label>
         <div class='input-group'>
-          <div class='input-group-btn'>
-            <button type='button' class='btn btn-default dropdown-toggle' data-toggle='dropdown' aria-haspopup='true'
-                    aria-expanded='false'>Name&nbsp;
+          <div class='input-group-btn' dropdown>
+            <button type='button' class='btn btn-default' aria-haspopup='true' aria-expanded='false' dropdownToggle>Name&nbsp;
               <span class='caret'></span>
             </button>
-            <ul class='dropdown-menu'>
+            <ul role="menu" dropdownMenu>
               <li>
                 <a href='#'>Name</a>
               </li>
@@ -31,12 +30,11 @@
       <!-- Toolbar: Sort -->
 
       <div class='form-group sort'>
-        <div class='dropdown btn-group'>
-          <button type='button' class='btn btn-default dropdown-toggle' data-toggle='dropdown' aria-haspopup='true'
-                  aria-expanded='false'>Name&nbsp;
+        <div class='btn-group' dropdown>
+          <button type='button' class='btn btn-default' aria-haspopup='true' aria-expanded='false' dropdownToggle>Name&nbsp;
             <span class='caret'></span>
           </button>
-          <ul class='dropdown-menu'>
+          <ul role="menu" dropdownMenu>
             <li>
               <a href='#'>Name</a>
             </li>

--- a/src/app/kubernetes/ui/deployment/list/list.deployment.component.html
+++ b/src/app/kubernetes/ui/deployment/list/list.deployment.component.html
@@ -6,12 +6,12 @@
         <input type='checkbox'>
       </div>
       <div class='list-view-pf-actions'>
-        <div class='dropdown pull-right dropdown-kebab-pf'>
-          <button class='btn btn-link dropdown-toggle' type='button' id='dropdownKebabRight9' data-toggle='dropdown'
-                  aria-haspopup='true' aria-expanded='true'>
+        <div class='pull-right dropdown-kebab-pf' dropdown>
+          <button class='btn btn-link' type='button' id='dropdownKebabRight9'
+                  aria-haspopup='true' aria-expanded='true' dropdownToggle>
             <span class='fa fa-ellipsis-v'></span>
           </button>
-          <ul class='dropdown-menu dropdown-menu-right' aria-labelledby='dropdownKebabRight9'>
+          <ul class='dropdown-menu-right' aria-labelledby='dropdownKebabRight9' role="menu" dropdownMenu>
             <li *ngIf="deployment.exposeUrl">
               <a target="deployment" [href]="deployment.exposeUrl"
                  title="Open this deployment in a separate browser tab">

--- a/src/app/kubernetes/ui/event/event.module.ts
+++ b/src/app/kubernetes/ui/event/event.module.ts
@@ -1,5 +1,6 @@
 import {NgModule} from "@angular/core";
 import {CommonModule} from "@angular/common";
+import {DropdownConfig, DropdownModule} from "ng2-bootstrap";
 import {FormsModule} from "@angular/forms";
 import {RouterModule, Routes} from "@angular/router";
 import {ModalModule} from "ng2-modal";
@@ -22,6 +23,7 @@ const routes: Routes = [
 @NgModule({
   imports: [
     CommonModule,
+    DropdownModule,
     FormsModule,
     ModalModule,
     MomentModule,
@@ -41,6 +43,9 @@ const routes: Routes = [
   exports: [
     ModalModule,
   ],
+  providers: [
+    DropdownConfig
+  ]
 })
 export class EventModule {
 }

--- a/src/app/kubernetes/ui/event/list-toolbar/list-toolbar.event.component.html
+++ b/src/app/kubernetes/ui/event/list-toolbar/list-toolbar.event.component.html
@@ -10,12 +10,11 @@
       <div class='form-group toolbar-pf-filter search'>
         <label class='sr-only'>Name</label>
         <div class='input-group'>
-          <div class='input-group-btn'>
-            <button type='button' class='btn btn-default dropdown-toggle' data-toggle='dropdown' aria-haspopup='true'
-                    aria-expanded='false'>Name&nbsp;
+          <div class='input-group-btn' dropdown>
+            <button type='button' class='btn btn-default' aria-haspopup='true' aria-expanded='false' dropdownToggle>Name&nbsp;
               <span class='caret'></span>
             </button>
-            <ul class='dropdown-menu'>
+            <ul role="menu" dropdownMenu>
               <li>
                 <a href='#'>Name</a>
               </li>
@@ -31,12 +30,11 @@
       <!-- Toolbar: Sort -->
 
       <div class='form-group sort'>
-        <div class='dropdown btn-group'>
-          <button type='button' class='btn btn-default dropdown-toggle' data-toggle='dropdown' aria-haspopup='true'
-                  aria-expanded='false'>Name&nbsp;
+        <div class='btn-group' dropdown>
+          <button type='button' class='btn btn-default' aria-haspopup='true' aria-expanded='false' dropdownToggle>Name&nbsp;
             <span class='caret'></span>
           </button>
-          <ul class='dropdown-menu'>
+          <ul role="menu" dropdownMenu>
             <li>
               <a href='#'>Name</a>
             </li>

--- a/src/app/kubernetes/ui/event/list/list.event.component.html
+++ b/src/app/kubernetes/ui/event/list/list.event.component.html
@@ -6,11 +6,11 @@
         <input type='checkbox'>
       </div>
       <div class='list-view-pf-actions'>
-        <div class='dropdown pull-right dropdown-kebab-pf'>
-          <button class='btn btn-link dropdown-toggle' type='button' id='dropdownKebabRight9' data-toggle='dropdown' aria-haspopup='true' aria-expanded='true'>
+        <div class='pull-right dropdown-kebab-pf' dropdown>
+          <button class='btn btn-link' type='button' id='dropdownKebabRight9' aria-haspopup='true' aria-expanded='true' dropdownToggle>
               <span class='fa fa-ellipsis-v'></span>
             </button>
-          <ul class='dropdown-menu dropdown-menu-right' aria-labelledby='dropdownKebabRight9'>
+          <ul class='dropdown-menu-right' aria-labelledby='dropdownKebabRight9' role="menu" dropdownMenu>
             <li>
               <a [routerLink]="[event.id, 'edit']">Edit</a>
             </li>

--- a/src/app/kubernetes/ui/namespace/list-toolbar/list-toolbar.namespace.component.html
+++ b/src/app/kubernetes/ui/namespace/list-toolbar/list-toolbar.namespace.component.html
@@ -7,11 +7,11 @@
       <div class='form-group toolbar-pf-filter search'>
         <label class='sr-only'>Name</label>
         <div class='input-group'>
-          <div class='input-group-btn'>
-            <button type='button' class='btn btn-default dropdown-toggle' data-toggle='dropdown' aria-haspopup='true' aria-expanded='false'>Name&nbsp;
+          <div class='input-group-btn' dropdown>
+            <button type='button' class='btn btn-default' aria-haspopup='true' aria-expanded='false' dropdownToggle>Name&nbsp;
                 <span class='caret'></span>
               </button>
-            <ul class='dropdown-menu'>
+            <ul role="menu" dropdownMenu>
               <li>
                 <a href='#'>Name</a>
               </li>
@@ -27,11 +27,11 @@
       <!-- Toolbar: Sort -->
 
       <div class='form-group sort'>
-        <div class='dropdown btn-group'>
-          <button type='button' class='btn btn-default dropdown-toggle' data-toggle='dropdown' aria-haspopup='true' aria-expanded='false'>Name&nbsp;
+        <div class='btn-group' dropdown>
+          <button type='button' class='btn btn-default' aria-haspopup='true' aria-expanded='false' dropdownToggle>Name&nbsp;
               <span class='caret'></span>
             </button>
-          <ul class='dropdown-menu'>
+          <ul role="menu" dropdownMenu>
             <li>
               <a href='#'>Name</a>
             </li>

--- a/src/app/kubernetes/ui/namespace/list/list.namespace.component.html
+++ b/src/app/kubernetes/ui/namespace/list/list.namespace.component.html
@@ -6,11 +6,11 @@
         <input type='checkbox'>
       </div>
       <div class='list-view-pf-actions'>
-        <div class='dropdown pull-right dropdown-kebab-pf'>
-          <button class='btn btn-link dropdown-toggle' type='button' id='dropdownKebabRight9' data-toggle='dropdown' aria-haspopup='true' aria-expanded='true'>
+        <div class='pull-right dropdown-kebab-pf' dropdown>
+          <button class='btn btn-link' type='button' id='dropdownKebabRight9' aria-haspopup='true' aria-expanded='true' dropdownToggle>
               <span class='fa fa-ellipsis-v'></span>
             </button>
-          <ul class='dropdown-menu dropdown-menu-right' aria-labelledby='dropdownKebabRight9'>
+          <ul class='dropdown-menu-right' aria-labelledby='dropdownKebabRight9' role="menu" dropdownMenu>
             <li>
               <a [routerLink]="[namespace.id]">View Details</a>
             </li>

--- a/src/app/kubernetes/ui/namespace/namespace.module.ts
+++ b/src/app/kubernetes/ui/namespace/namespace.module.ts
@@ -1,5 +1,6 @@
 import {NgModule} from "@angular/core";
 import {CommonModule} from "@angular/common";
+import {DropdownConfig, DropdownModule} from "ng2-bootstrap";
 import {FormsModule} from "@angular/forms";
 import {RouterModule, Routes} from "@angular/router";
 import {ModalModule} from "ng2-modal";
@@ -28,6 +29,7 @@ const routes: Routes = [
 @NgModule({
   imports: [
     CommonModule,
+    DropdownModule,
     FormsModule,
     ModalModule,
     MomentModule,
@@ -57,6 +59,9 @@ const routes: Routes = [
   exports: [
     ModalModule,
   ],
+  providers: [
+    DropdownConfig
+  ]
 })
 export class NamespaceModule {
 }

--- a/src/app/kubernetes/ui/pipeline/full-history-toolbar/full-history-toolbar.pipeline.component.html
+++ b/src/app/kubernetes/ui/pipeline/full-history-toolbar/full-history-toolbar.pipeline.component.html
@@ -12,12 +12,11 @@
       <div class='form-group toolbar-pf-filter search'>
         <label class='sr-only'>Name</label>
         <div class='input-group'>
-          <div class='input-group-btn'>
-            <button type='button' class='btn btn-default dropdown-toggle' data-toggle='dropdown' aria-haspopup='true'
-                    aria-expanded='false'>Name&nbsp;
+          <div class='input-group-btn' dropdown>
+            <button type='button' class='btn btn-default' aria-haspopup='true' aria-expanded='false' dropdownToggle>Name&nbsp;
               <span class='caret'></span>
             </button>
-            <ul class='dropdown-menu'>
+            <ul role="menu" dropdownMenu>
               <li>
                 <a href='#'>Name</a>
               </li>
@@ -33,12 +32,11 @@
       <!-- Toolbar: Sort -->
 
       <div class='form-group sort'>
-        <div class='dropdown btn-group'>
-          <button type='button' class='btn btn-default dropdown-toggle' data-toggle='dropdown' aria-haspopup='true'
-                  aria-expanded='false'>Name&nbsp;
+        <div class='btn-group' dropdown>
+          <button type='button' class='btn btn-default' aria-haspopup='true' aria-expanded='false' dropdownToggle>Name&nbsp;
             <span class='caret'></span>
           </button>
-          <ul class='dropdown-menu'>
+          <ul role="menu" dropdownMenu>
             <li>
               <a href='#'>Name</a>
             </li>

--- a/src/app/kubernetes/ui/pipeline/full-history/full-history.pipeline.component.html
+++ b/src/app/kubernetes/ui/pipeline/full-history/full-history.pipeline.component.html
@@ -15,12 +15,12 @@
               </small>
             </h3>
 
-            <div class='dropdown pull-right dropdown-kebab-pf'>
-              <button class='btn btn-link dropdown-toggle' type='button' id='dropdownKebabRight9' data-toggle='dropdown'
-                      aria-haspopup='true' aria-expanded='true'>
+            <div class='pull-right dropdown-kebab-pf' dropdown>
+              <button class='btn btn-link' type='button' id='dropdownKebabRight9'
+                      aria-haspopup='true' aria-expanded='true' dropdownToggle>
                 <span class='fa fa-ellipsis-v'></span>
               </button>
-              <ul class='dropdown-menu dropdown-menu-right' aria-labelledby='dropdownKebabRight9'>
+              <ul class='dropdown-menu dropdown-menu-right' aria-labelledby='dropdownKebabRight9' role="menu" dropdownMenu>
                 <li *ngIf="pipeline.lastBuildPath">
                   <a routerLink="{{pipeline.lastBuildPath}}" title="view last build">
                     View last build

--- a/src/app/kubernetes/ui/pipeline/history/history.pipeline.component.html
+++ b/src/app/kubernetes/ui/pipeline/history/history.pipeline.component.html
@@ -16,12 +16,12 @@
               </small>
             </h3>
 
-            <div class='dropdown pull-right dropdown-kebab-pf'>
-              <button class='btn btn-link dropdown-toggle' type='button' id='dropdownKebabRight9' data-toggle='dropdown'
-                      aria-haspopup='true' aria-expanded='true'>
+            <div class='pull-right dropdown-kebab-pf' dropdown>
+              <button class='btn btn-link' type='button' id='dropdownKebabRight9'
+                      aria-haspopup='true' aria-expanded='true' dropdownToggle>
                 <span class='fa fa-ellipsis-v'></span>
               </button>
-              <ul class='dropdown-menu dropdown-menu-right' aria-labelledby='dropdownKebabRight9'>
+              <ul class='dropdown-menu-right' aria-labelledby='dropdownKebabRight9' role="menu" dropdownMenu>
                 <li *ngIf="pipeline.lastBuildPath">
                   <a routerLink="{{pipeline.lastBuildPath}}" title="view last build">
                     View last build

--- a/src/app/kubernetes/ui/pipeline/list/list.pipeline.component.html
+++ b/src/app/kubernetes/ui/pipeline/list/list.pipeline.component.html
@@ -12,12 +12,12 @@
               <small>created {{pipeline.creationTimestamp | amTimeAgo}}</small>
             </h3>
 
-            <div class='dropdown pull-right dropdown-kebab-pf'>
-              <button class='btn btn-link dropdown-toggle' type='button' id='dropdownKebabRight9' data-toggle='dropdown'
-                      aria-haspopup='true' aria-expanded='true'>
+            <div class='pull-right dropdown-kebab-pf' dropdown>
+              <button class='btn btn-link' type='button' id='dropdownKebabRight9'
+                      aria-haspopup='true' aria-expanded='true' dropdownToggle>
                 <span class='fa fa-ellipsis-v'></span>
               </button>
-              <ul class='dropdown-menu dropdown-menu-right' aria-labelledby='dropdownKebabRight9'>
+              <ul class='dropdown-menu-right' aria-labelledby='dropdownKebabRight9' role="menu" dropdownMenu>
                 <li *ngIf="pipeline.lastBuildPath">
                   <a routerLink="{{pipeline.lastBuildPath}}" title="view last build">
                     View last build

--- a/src/app/kubernetes/ui/pipeline/pipeline-full-history.module.ts
+++ b/src/app/kubernetes/ui/pipeline/pipeline-full-history.module.ts
@@ -1,5 +1,6 @@
 import {NgModule} from "@angular/core";
 import {CommonModule} from "@angular/common";
+import {DropdownConfig, DropdownModule} from "ng2-bootstrap";
 import {FormsModule} from "@angular/forms";
 import {RouterModule, Routes} from "@angular/router";
 import {ModalModule} from "ng2-modal";
@@ -17,6 +18,7 @@ const routes: Routes = [
 @NgModule({
   imports: [
     CommonModule,
+    DropdownModule,
     FormsModule,
     ModalModule,
     MomentModule,
@@ -32,6 +34,9 @@ const routes: Routes = [
   ],
   exports: [
   ],
+  providers: [
+    DropdownConfig
+  ]
 })
 export class PipelineFullHistoryModule {
 }

--- a/src/app/kubernetes/ui/pipeline/pipeline.module.ts
+++ b/src/app/kubernetes/ui/pipeline/pipeline.module.ts
@@ -1,5 +1,6 @@
 import {NgModule} from "@angular/core";
 import {CommonModule} from "@angular/common";
+import {DropdownConfig, DropdownModule} from "ng2-bootstrap";
 import {FormsModule} from "@angular/forms";
 import {RouterModule, Routes} from "@angular/router";
 import {ModalModule} from "ng2-modal";
@@ -30,6 +31,7 @@ const routes: Routes = [
 @NgModule({
   imports: [
     CommonModule,
+    DropdownModule,
     FormsModule,
     ModalModule,
     MomentModule,
@@ -60,6 +62,9 @@ const routes: Routes = [
     PipelinesListComponent,
     PipelinesListToolbarComponent,
   ],
+  providers: [
+    DropdownConfig
+  ]
 })
 export class PipelineModule {
 }

--- a/src/app/kubernetes/ui/pod/list-toolbar/list-toolbar.pod.component.html
+++ b/src/app/kubernetes/ui/pod/list-toolbar/list-toolbar.pod.component.html
@@ -10,12 +10,11 @@
       <div class='form-group toolbar-pf-filter search'>
         <label class='sr-only'>Name</label>
         <div class='input-group'>
-          <div class='input-group-btn'>
-            <button type='button' class='btn btn-default dropdown-toggle' data-toggle='dropdown' aria-haspopup='true'
-                    aria-expanded='false'>Name&nbsp;
+          <div class='input-group-btn' dropdown>
+            <button type='button' class='btn btn-default' aria-haspopup='true' aria-expanded='false' dropdownToggle>Name&nbsp;
               <span class='caret'></span>
             </button>
-            <ul class='dropdown-menu'>
+            <ul role="menu" dropdownMenu>
               <li>
                 <a href='#'>Name</a>
               </li>
@@ -31,12 +30,11 @@
       <!-- Toolbar: Sort -->
 
       <div class='form-group sort'>
-        <div class='dropdown btn-group'>
-          <button type='button' class='btn btn-default dropdown-toggle' data-toggle='dropdown' aria-haspopup='true'
-                  aria-expanded='false'>Name&nbsp;
+        <div class='btn-group' dropdown>
+          <button type='button' class='btn btn-default' aria-haspopup='true' aria-expanded='false' dropdownToggle>Name&nbsp;
             <span class='caret'></span>
           </button>
-          <ul class='dropdown-menu'>
+          <ul role="menu" dropdownMenu>
             <li>
               <a href='#'>Name</a>
             </li>

--- a/src/app/kubernetes/ui/pod/list/list.pod.component.html
+++ b/src/app/kubernetes/ui/pod/list/list.pod.component.html
@@ -6,11 +6,11 @@
         <input type='checkbox'>
       </div>
       <div class='list-view-pf-actions'>
-        <div class='dropdown pull-right dropdown-kebab-pf'>
-          <button class='btn btn-link dropdown-toggle' type='button' id='dropdownKebabRight9' data-toggle='dropdown' aria-haspopup='true' aria-expanded='true'>
+        <div class='pull-right dropdown-kebab-pf' dropdown>
+          <button class='btn btn-link' type='button' id='dropdownKebabRight9' aria-haspopup='true' aria-expanded='true' dropdownToggle>
               <span class='fa fa-ellipsis-v'></span>
             </button>
-          <ul class='dropdown-menu dropdown-menu-right' aria-labelledby='dropdownKebabRight9'>
+          <ul class='dropdown-menu-right' aria-labelledby='dropdownKebabRight9' role="menu" dropdownMenu>
             <li>
               <a [routerLink]="[pod.id, 'edit']">Edit</a>
             </li>

--- a/src/app/kubernetes/ui/pod/pod.module.ts
+++ b/src/app/kubernetes/ui/pod/pod.module.ts
@@ -1,5 +1,6 @@
 import {NgModule} from "@angular/core";
 import {CommonModule} from "@angular/common";
+import {DropdownConfig, DropdownModule} from "ng2-bootstrap";
 import {FormsModule} from "@angular/forms";
 import {RouterModule, Routes} from "@angular/router";
 import {ModalModule} from "ng2-modal";
@@ -28,6 +29,7 @@ const routes: Routes = [
 @NgModule({
   imports: [
     CommonModule,
+    DropdownModule,
     FormsModule,
     ModalModule,
     MomentModule,
@@ -56,6 +58,9 @@ const routes: Routes = [
   exports: [
     ModalModule,
   ],
+  providers: [
+    DropdownConfig
+  ]
 })
 export class PodModule {
 }

--- a/src/app/kubernetes/ui/replicaset/list-toolbar/list-toolbar.replicaset.component.html
+++ b/src/app/kubernetes/ui/replicaset/list-toolbar/list-toolbar.replicaset.component.html
@@ -10,12 +10,11 @@
       <div class='form-group toolbar-pf-filter search'>
         <label class='sr-only'>Name</label>
         <div class='input-group'>
-          <div class='input-group-btn'>
-            <button type='button' class='btn btn-default dropdown-toggle' data-toggle='dropdown' aria-haspopup='true'
-                    aria-expanded='false'>Name&nbsp;
+          <div class='input-group-btn' dropdown>
+            <button type='button' class='btn btn-default' aria-haspopup='true' aria-expanded='false' dropdownToggle>Name&nbsp;
               <span class='caret'></span>
             </button>
-            <ul class='dropdown-menu'>
+            <ul role="menu" dropdownMenu>
               <li>
                 <a href='#'>Name</a>
               </li>
@@ -31,12 +30,11 @@
       <!-- Toolbar: Sort -->
 
       <div class='form-group sort'>
-        <div class='dropdown btn-group'>
-          <button type='button' class='btn btn-default dropdown-toggle' data-toggle='dropdown' aria-haspopup='true'
-                  aria-expanded='false'>Name&nbsp;
+        <div class='btn-group' dropdown>
+          <button type='button' class='btn btn-default' aria-haspopup='true' aria-expanded='false' dropdownToggle>Name&nbsp;
             <span class='caret'></span>
           </button>
-          <ul class='dropdown-menu'>
+          <ul role="menu" dropdownMenu>
             <li>
               <a href='#'>Name</a>
             </li>

--- a/src/app/kubernetes/ui/replicaset/list/list.replicaset.component.html
+++ b/src/app/kubernetes/ui/replicaset/list/list.replicaset.component.html
@@ -6,11 +6,11 @@
         <input type='checkbox'>
       </div>
       <div class='list-view-pf-actions'>
-        <div class='dropdown pull-right dropdown-kebab-pf'>
-          <button class='btn btn-link dropdown-toggle' type='button' id='dropdownKebabRight9' data-toggle='dropdown' aria-haspopup='true' aria-expanded='true'>
+        <div class='pull-right dropdown-kebab-pf' dropdown>
+          <button class='btn btn-link' type='button' id='dropdownKebabRight9' aria-haspopup='true' aria-expanded='true' dropdownToggle>
               <span class='fa fa-ellipsis-v'></span>
             </button>
-          <ul class='dropdown-menu dropdown-menu-right' aria-labelledby='dropdownKebabRight9'>
+          <ul class='dropdown-menu-right' aria-labelledby='dropdownKebabRight9' role="menu" dropdownMenu>
             <li *ngIf="replicaset.exposeUrl">
               <a target="replicaset" [href]="replicaset.exposeUrl"
                  title="Open this replicaset in a separate browser tab">

--- a/src/app/kubernetes/ui/replicaset/replicaset.module.ts
+++ b/src/app/kubernetes/ui/replicaset/replicaset.module.ts
@@ -1,5 +1,6 @@
 import {NgModule} from "@angular/core";
 import {CommonModule} from "@angular/common";
+import {DropdownConfig, DropdownModule} from "ng2-bootstrap";
 import {FormsModule} from "@angular/forms";
 import {RouterModule, Routes} from "@angular/router";
 import {ModalModule} from "ng2-modal";
@@ -29,6 +30,7 @@ const routes: Routes = [
 @NgModule({
   imports: [
     CommonModule,
+    DropdownModule,
     FormsModule,
     ModalModule,
     MomentModule,
@@ -58,6 +60,9 @@ const routes: Routes = [
   exports: [
     ModalModule,
   ],
+  providers: [
+    DropdownConfig
+  ]
 })
 export class ReplicaSetModule {
 }

--- a/src/app/kubernetes/ui/service/list-toolbar/list-toolbar.service.component.html
+++ b/src/app/kubernetes/ui/service/list-toolbar/list-toolbar.service.component.html
@@ -10,12 +10,11 @@
       <div class='form-group toolbar-pf-filter search'>
         <label class='sr-only'>Name</label>
         <div class='input-group'>
-          <div class='input-group-btn'>
-            <button type='button' class='btn btn-default dropdown-toggle' data-toggle='dropdown' aria-haspopup='true'
-                    aria-expanded='false'>Name&nbsp;
+          <div class='input-group-btn' dropdown>
+            <button type='button' class='btn btn-default' aria-haspopup='true' aria-expanded='false' dropdownToggle>Name&nbsp;
               <span class='caret'></span>
             </button>
-            <ul class='dropdown-menu'>
+            <ul role="menu" dropdownMenu>
               <li>
                 <a href='#'>Name</a>
               </li>
@@ -31,12 +30,11 @@
       <!-- Toolbar: Sort -->
 
       <div class='form-group sort'>
-        <div class='dropdown btn-group'>
-          <button type='button' class='btn btn-default dropdown-toggle' data-toggle='dropdown' aria-haspopup='true'
-                  aria-expanded='false'>Name&nbsp;
+        <div class='btn-group' dropdown>
+          <button type='button' class='btn btn-default' aria-haspopup='true' aria-expanded='false' dropdownToggle>Name&nbsp;
             <span class='caret'></span>
           </button>
-          <ul class='dropdown-menu'>
+          <ul role="menu" dropdownMenu>
             <li>
               <a href='#'>Name</a>
             </li>

--- a/src/app/kubernetes/ui/service/list/list.service.component.html
+++ b/src/app/kubernetes/ui/service/list/list.service.component.html
@@ -6,11 +6,11 @@
         <input type='checkbox'>
       </div>
       <div class='list-view-pf-actions'>
-        <div class='dropdown pull-right dropdown-kebab-pf'>
-          <button class='btn btn-link dropdown-toggle' type='button' id='dropdownKebabRight9' data-toggle='dropdown' aria-haspopup='true' aria-expanded='true'>
+        <div class='pull-right dropdown-kebab-pf' dropdown>
+          <button class='btn btn-link' type='button' id='dropdownKebabRight9' aria-haspopup='true' aria-expanded='true' dropdownToggle>
               <span class='fa fa-ellipsis-v'></span>
             </button>
-          <ul class='dropdown-menu dropdown-menu-right' aria-labelledby='dropdownKebabRight9'>
+          <ul class='dropdown-menu-right' aria-labelledby='dropdownKebabRight9' role="menu" dropdownMenu>
             <li>
               <a [routerLink]="[service.id, 'edit']">Edit</a>
             </li>

--- a/src/app/kubernetes/ui/service/service.module.ts
+++ b/src/app/kubernetes/ui/service/service.module.ts
@@ -1,5 +1,6 @@
 import {NgModule} from "@angular/core";
 import {CommonModule} from "@angular/common";
+import {DropdownConfig, DropdownModule} from "ng2-bootstrap";
 import {FormsModule} from "@angular/forms";
 import {RouterModule, Routes} from "@angular/router";
 import {ModalModule} from "ng2-modal";
@@ -28,6 +29,7 @@ const routes: Routes = [
 @NgModule({
   imports: [
     CommonModule,
+    DropdownModule,
     FormsModule,
     ModalModule,
     MomentModule,
@@ -56,6 +58,9 @@ const routes: Routes = [
   exports: [
     ModalModule,
   ],
+  providers: [
+    DropdownConfig
+  ]
 })
 export class ServiceModule {
 }

--- a/src/app/kubernetes/ui/space/list-toolbar/list-toolbar.space.component.html
+++ b/src/app/kubernetes/ui/space/list-toolbar/list-toolbar.space.component.html
@@ -7,11 +7,11 @@
       <div class='form-group toolbar-pf-filter search'>
         <label class='sr-only'>Name</label>
         <div class='input-group'>
-          <div class='input-group-btn'>
-            <button type='button' class='btn btn-default dropdown-toggle' data-toggle='dropdown' aria-haspopup='true' aria-expanded='false'>Name&nbsp;
+          <div class='input-group-btn' dropdown>
+            <button type='button' class='btn btn-default' aria-haspopup='true' aria-expanded='false' dropdownToggle>Name&nbsp;
                 <span class='caret'></span>
               </button>
-            <ul class='dropdown-menu'>
+            <ul role="menu" dropdownMenu>
               <li>
                 <a href='#'>Name</a>
               </li>
@@ -27,11 +27,11 @@
       <!-- Toolbar: Sort -->
 
       <div class='form-group sort'>
-        <div class='dropdown btn-group'>
-          <button type='button' class='btn btn-default dropdown-toggle' data-toggle='dropdown' aria-haspopup='true' aria-expanded='false'>Name&nbsp;
+        <div class='dropdown btn-group' dropdown>
+          <button type='button' class='btn btn-default' aria-haspopup='true' aria-expanded='false' dropdownToggle>Name&nbsp;
               <span class='caret'></span>
             </button>
-          <ul class='dropdown-menu'>
+          <ul role="menu" dropdownMenu>
             <li>
               <a href='#'>Name</a>
             </li>

--- a/src/app/kubernetes/ui/space/list/list.space.component.html
+++ b/src/app/kubernetes/ui/space/list/list.space.component.html
@@ -6,11 +6,11 @@
         <input type='checkbox'>
       </div>
       <div class='list-view-pf-actions'>
-        <div class='dropdown pull-right dropdown-kebab-pf'>
-          <button class='btn btn-link dropdown-toggle' type='button' id='dropdownKebabRight9' data-toggle='dropdown' aria-haspopup='true' aria-expanded='true'>
+        <div class='pull-right dropdown-kebab-pf' dropdown>
+          <button class='btn btn-link' type='button' id='dropdownKebabRight9' aria-haspopup='true' aria-expanded='true' dropdownToggle>
               <span class='fa fa-ellipsis-v'></span>
             </button>
-          <ul class='dropdown-menu dropdown-menu-right' aria-labelledby='dropdownKebabRight9'>
+          <ul class='dropdown-menu-right' aria-labelledby='dropdownKebabRight9' role="menu" dropdownMenu>
             <li>
               <a [routerLink]="[space.id]">View Details</a>
             </li>

--- a/src/app/kubernetes/ui/space/space.module.ts
+++ b/src/app/kubernetes/ui/space/space.module.ts
@@ -1,4 +1,5 @@
 import {NgModule} from "@angular/core";
+import {DropdownConfig, DropdownModule} from "ng2-bootstrap";
 import {CommonModule} from "@angular/common";
 import {FormsModule} from "@angular/forms";
 import {RouterModule, Routes} from "@angular/router";
@@ -34,6 +35,7 @@ const routes: Routes = [
 @NgModule({
   imports: [
     CommonModule,
+    DropdownModule,
     FormsModule,
     ModalModule,
     MomentModule,
@@ -57,6 +59,7 @@ const routes: Routes = [
     SpaceDeleteDialog,
   ],
   providers: [
+    DropdownConfig,
     SpaceStore,
     NamespaceStore,
     ConfigMapService,


### PR DESCRIPTION
This fixes issue #108 by converting drop down menus and kebabs to use ng2-bootstrap as done with ngx-widgets, and the platform/planner UIs. Previous to this change, only the dropdown menus in the header are working.