### PR TITLE
feat(environments): Initial support for env page

### DIFF
--- a/environments/openshift-free-int-cluster.sh
+++ b/environments/openshift-free-int-cluster.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+
+export KUBERNETES_SERVICE_HOST=api.free-int.openshift.com
+export KUBERNETES_SERVICE_PORT=443
+
+echo "Using Kubernetes Master: ${KUBERNETES_SERVICE_HOST}:${KUBERNETES_SERVICE_PORT}"
+
+[ -z "$KUBERNETES_SERVICE_HOST" ] && IFS=':' read KUBERNETES_SERVICE_HOST KUBERNETES_SERVICE_PORT <<< "$PARTS"
+[ -z "$KUBERNETES_SERVICE_HOST" ] && echo "Need to set KUBERNETES_SERVICE_HOST" && exit 1;
+[ -z "$KUBERNETES_SERVICE_PORT" ] && echo "Need to set KUBERNETES_SERVICE_PORT" && exit 1;
+
+
+export OAUTH_AUTHORIZE_URI="https://${KUBERNETES_SERVICE_HOST}:${KUBERNETES_SERVICE_PORT}/oauth/authorize"
+export OAUTH_LOGOUT_URI="https://${KUBERNETES_SERVICE_HOST}:${KUBERNETES_SERVICE_PORT}/connect/endsession?id_token={{id_token}}"
+# This is devshift
+export PROXIED_K8S_API_SERVER="${KUBERNETES_SERVICE_HOST}:${KUBERNETES_SERVICE_PORT}"
+# This is our proxy that we will connect to
+export K8S_API_SERVER="localhost:4200"
+
+if [ -z "${OAUTH_ISSUER}" ]; then
+  export OAUTH_ISSUER="https://${KUBERNETES_SERVICE_HOST}:${KUBERNETES_SERVICE_PORT}"
+fi
+if [ -z "${OAUTH_SCOPE}" ]; then
+  export OAUTH_SCOPE="user:full"
+fi
+if [ -z "${OAUTH_CLIENT_ID}" ]; then
+  export OAUTH_CLIENT_ID="fabric8"
+fi
+if [ -z "${K8S_API_SERVER_PROTOCOL}" ]; then
+  export K8S_API_SERVER_PROTOCOL="http"
+fi
+if [ -z "${K8S_API_SERVER_BASE_PATH}" ]; then
+  export K8S_API_SERVER_BASE_PATH="/_p/oso"
+fi
+if [ -z "${WS_K8S_API_SERVER}" ]; then
+  export WS_K8S_API_SERVER=${PROXIED_K8S_API_SERVER}
+fi
+if [ -z "${FABRIC8_PIPELINES_NAMESPACE}" ]; then
+  export FABRIC8_PIPELINES_NAMESPACE=""
+fi
+
+echo "Configured to connect to kubernetes cluster at https://${PROXIED_K8S_API_SERVER}/"
+
+echo ""
+echo "WS_K8S_API_SERVER:             ${WS_K8S_API_SERVER}"
+echo "K8S_API_SERVER_PROTOCOL:       ${K8S_API_SERVER_PROTOCOL}"
+echo "K8S_API_SERVER_BASE_PATH:      ${K8S_API_SERVER_BASE_PATH}"
+echo "OAUTH_ISSUER:                  ${OAUTH_ISSUER}"
+echo "OAUTH_CLIENT_ID:               ${OAUTH_CLIENT_ID}"
+echo "OAUTH_SCOPE:                   ${OAUTH_SCOPE}"
+echo "OAUTH_AUTHORIZE_URI            ${OAUTH_AUTHORIZE_URI}"
+echo "OAUTH_LOGOUT_URI               ${OAUTH_LOGOUT_URI}"
+echo "FABRIC8_PIPELINES_NAMESPACE    ${FABRIC8_PIPELINES_NAMESPACE}"
+echo ""

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "ngx-base": "1.2.0",
     "ngx-fabric8-wit": "6.15.2",
     "ngx-login-client": "0.6.5",
+    "ngx-widgets": "0.10.4",
     "rxjs": "5.0.1"
   },
   "devDependencies": {

--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -1,1 +1,14 @@
 @import '../assets/stylesheets/base';
+
+// Overrides for environment view
+// TODO HACK Temp hack as we will switch to the compound list view soon
+.environment-listing {
+  .toggle-children-placeholder {
+    display: none;
+  }
+
+  .list-group {
+    margin-top: 0px;
+    margin-bottom: 0px;
+  }
+}

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -3,7 +3,7 @@ import {OAuthService} from "angular2-oauth2/oauth-service";
 import {OAuthConfigStore} from "./kubernetes/store/oauth-config-store";
 import {Observable} from "rxjs";
 import {OnLogin} from "./shared/onlogin.service";
-import {ActivatedRoute} from '@angular/router';
+import {ActivatedRoute, Router} from '@angular/router';
 import {LoginService} from './shared/login.service';
 // import { jquery as $ } from 'jquery';
 
@@ -28,7 +28,8 @@ export class AppComponent implements OnInit, AfterViewInit {
               private oauthConfigStore: OAuthConfigStore,
               private onLogin: OnLogin,
               private activatedRoute: ActivatedRoute,
-              private loginService: LoginService) {
+              private loginService: LoginService,
+              private router: Router) {
 
     // change this to false to use platform authentication directly instead of the custom openshift oauth
     this.loginService.useCustomAuth = true;

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -42,10 +42,7 @@ export function restangularProviderConfigurer(restangularProvider: any, config: 
     HttpModule,
     RestangularModule.forRoot([ConfigService], restangularProviderConfigurer),
     NgbModule.forRoot(),
-    AppRoutingModule,
     DropdownModule,
-
-
     Fabric8CommonModule,
     KubernetesStoreModule,
     KubernetesUIModule,
@@ -53,6 +50,8 @@ export function restangularProviderConfigurer(restangularProvider: any, config: 
       prefix: 'fabric8',
       storageType: 'localStorage'
     }),
+    // Load app routing last
+    AppRoutingModule,
   ],
   declarations: [
     AppComponent,

--- a/src/app/dummy/dummy.service.ts
+++ b/src/app/dummy/dummy.service.ts
@@ -515,19 +515,23 @@ export class DummyService implements OnInit {
   }
 
 
-  private createUrlPrefix(ns: string, spaceName: string, label: string, app: string) {
+  private createUrlPrefix(ns: string, spaceName: string, label: string, app: string, environments: boolean) {
     if (!ns) {
       return "/run/spaces";
     }
     if (spaceName) {
       if (label) {
-        if (app) {
+        if (environments) {
+          return pathJoin("/run/space", spaceName, "label", label, "environments");
+        } else if (app) {
           return pathJoin("/run/space", spaceName, "label", label, "app", app, "namespaces", ns);
         } else {
           return pathJoin("/run/space", spaceName, "label", label, "namespaces", ns);
         }
       } else {
-        if (app) {
+        if (environments) {
+          return pathJoin("/run/space", spaceName, "environments");
+        } else if (app) {
           return pathJoin("/run/space/", spaceName, "app", app, "/namespaces/", ns);
         } else {
           return pathJoin("/run/space/", spaceName, "/namespaces/", ns);
@@ -655,7 +659,7 @@ export class DummyService implements OnInit {
       firstEnvNamespace = space.environments[0].namespaceName;
     }
     var ns = params["namespace"] || firstEnvNamespace || spaceName;
-    let prefix = this.createUrlPrefix(ns, spaceName, label, app);
+    let prefix = this.createUrlPrefix(ns, spaceName, label, app, false);
 
     let runPath = prefix + this.currentRunResourcePath();
     let buildPath = prefix + '/builds';
@@ -679,7 +683,7 @@ export class DummyService implements OnInit {
     var app = params["app"];
     var label = labelSpace.name;
 
-    let prefix = this.createUrlPrefix(ns, spaceName, label, app);
+    let prefix = this.createUrlPrefix(ns, spaceName, label, app, false);
     let runPath = prefix + this.currentRunResourcePath();
 
     let buildPath = prefix + '/builds';
@@ -822,12 +826,17 @@ export class DummyService implements OnInit {
       if (environments && environments.length) {
         runMenus.push({
           name: "Tools",
-          path: this.createUrlPrefix(space.name, space.name, label, app) + resourcePath,
+          path: this.createUrlPrefix(space.name, space.name, label, app, false) + resourcePath,
+        });
+
+        runMenus.push({
+          name: "Environments",
+          path: this.createUrlPrefix(space.name, space.name, label, app, true),
         });
 
         environments.forEach(env => {
           var envName = env.name;
-          let prefix = this.createUrlPrefix(env.namespaceName, space.name, label, app);
+          let prefix = this.createUrlPrefix(env.namespaceName, space.name, label, app, false);
           var path = prefix + resourcePath;
           runMenus.push({
             name: envName,

--- a/src/app/kubernetes/service/namespace.scope.ts
+++ b/src/app/kubernetes/service/namespace.scope.ts
@@ -1,6 +1,7 @@
-import {Injectable} from '@angular/core';
-import {ActivatedRoute, Router, NavigationEnd} from "@angular/router";
-import {Observable} from 'rxjs';
+import { Injectable } from '@angular/core';
+import { ActivatedRoute, Router, NavigationEnd } from "@angular/router";
+import { Observable } from 'rxjs';
+import { merge } from 'lodash';
 
 @Injectable()
 export class NamespaceScope {
@@ -19,11 +20,30 @@ export class NamespaceScope {
   }
 
   protected getNamespace(params) {
-    return params['namespace'] || this.defaultNamespace();
+    return this.getRouteParams()['namespace'] || this.defaultNamespace();
   }
 
   defaultNamespace(): string {
     // TODO use some other mechanism to return the default?
     return 'default';
   }
+
+  private getRouteParams(): any {
+    if (
+      this.router &&
+      this.router.routerState &&
+      this.router.routerState.snapshot &&
+      this.router.routerState.snapshot.root
+    ) {
+      let firstChild = this.router.routerState.snapshot.root.firstChild;
+      let res = {};
+      while (firstChild) {
+        res = merge(res, firstChild.params);
+        firstChild = firstChild.firstChild;
+      }
+      return res;
+    }
+    return null;
+  }
+
 }

--- a/src/app/kubernetes/ui/configmap/configmap.module.ts
+++ b/src/app/kubernetes/ui/configmap/configmap.module.ts
@@ -57,6 +57,7 @@ const routes: Routes = [
   ],
   exports: [
     ModalModule,
+    ConfigMapsListComponent,
   ],
   providers: [
     DropdownConfig

--- a/src/app/kubernetes/ui/configmap/list/list.configmap.component.html
+++ b/src/app/kubernetes/ui/configmap/list/list.configmap.component.html
@@ -12,7 +12,7 @@
             </button>
           <ul class='dropdown-menu-right' aria-labelledby='dropdownKebabRight9' role="menu" dropdownMenu>
             <li>
-              <a [routerLink]="[configmap.id, 'edit']">Edit</a>
+              <a [routerLink]="[prefixPath(configmap.id), 'edit']">Edit</a>
             </li>
 
             <li>
@@ -29,7 +29,7 @@
         <div class='list-view-pf-body'>
           <div class='list-view-pf-description'>
             <div class='list-group-item-heading'>
-              <a [routerLink]="[configmap.id]" class="card-title" title="view configmap">{{ configmap.name }}</a>
+              <a [routerLink]="[prefixPath(configmap.id)]" class="card-title" title="view configmap">{{ configmap.name }}</a>
             </div>
             <div class='list-group-item-text'>
               <span class="" *ngFor='let image of configmap.images' title="docker image">

--- a/src/app/kubernetes/ui/configmap/list/list.configmap.component.ts
+++ b/src/app/kubernetes/ui/configmap/list/list.configmap.component.ts
@@ -1,6 +1,6 @@
-import {Component, Input, ViewChild} from "@angular/core";
-import {ConfigMapDeleteDialog} from "../delete-dialog/delete-dialog.configmap.component";
-import {ConfigMaps} from "../../../model/configmap.model";
+import { Component, Input, ViewChild } from "@angular/core";
+import { ConfigMapDeleteDialog } from "../delete-dialog/delete-dialog.configmap.component";
+import { ConfigMaps } from "../../../model/configmap.model";
 
 @Component({
   selector: 'fabric8-configmaps-list',
@@ -13,12 +13,18 @@ export class ConfigMapsListComponent {
 
   @Input() loading: boolean;
 
+  @Input() prefix: string;
+
   @ViewChild(ConfigMapDeleteDialog) deleteDialog: ConfigMapDeleteDialog;
 
   openDeleteDialog(deleteConfigMapModal, configmap) {
     this.deleteDialog.modal = deleteConfigMapModal;
     this.deleteDialog.configmap = configmap;
     deleteConfigMapModal.open();
+  }
+
+  prefixPath(pathComponent: string) {
+    return (this.prefix ? this.prefix + '/' : '') + pathComponent;
   }
 
 }

--- a/src/app/kubernetes/ui/deployment/deployment-routing.module.ts
+++ b/src/app/kubernetes/ui/deployment/deployment-routing.module.ts
@@ -1,4 +1,3 @@
-import { DeploymentRoutingModule } from './deployment-routing.module';
 import {NgModule} from "@angular/core";
 import {CommonModule} from "@angular/common";
 import {DropdownConfig, DropdownModule} from "ng2-bootstrap";
@@ -22,43 +21,19 @@ import {MomentModule} from "angular2-moment";
 import {KubernetesComponentsModule} from "../../components/components.module";
 import {DeploymentScaleDialog} from './scale-dialog/scale-dialog.deployment.component';
 
+const routes: Routes = [
+  { path: '', component: DeploymentsListPage },
+  { path: ':id', component: DeploymentViewPage },
+  { path: ':id/edit', component: DeploymentEditPage },
+];
+
 @NgModule({
   imports: [
-    CommonModule,
-    DropdownModule,
-    FormsModule,
-    ModalModule,
-    MomentModule,
-    Fabric8CommonModule,
-    KubernetesComponentsModule,
-    DeploymentRoutingModule,
-  ],
-  declarations: [
-    DeploymentsListPage,
-    DeploymentsListToolbarComponent,
-    DeploymentsListComponent,
-    DeploymentViewPage,
-    DeploymentViewWrapperComponent,
-    DeploymentViewToolbarComponent,
-    DeploymentViewComponent,
-    DeploymentEditPage,
-    DeploymentEditWrapperComponent,
-    DeploymentEditToolbarComponent,
-    DeploymentEditComponent,
-    DeploymentDeleteDialog,
-    DeploymentScaleDialog,
-  ],
-  entryComponents: [
-    DeploymentDeleteDialog,
-    DeploymentEditPage,
+    RouterModule.forChild(routes),
   ],
   exports: [
-    ModalModule,
-    DeploymentsListComponent,
+    RouterModule,
   ],
-  providers: [
-    DropdownConfig
-  ]
 })
-export class DeploymentModule {
+export class DeploymentRoutingModule {
 }

--- a/src/app/kubernetes/ui/deployment/list/list.deployment.component.html
+++ b/src/app/kubernetes/ui/deployment/list/list.deployment.component.html
@@ -26,7 +26,7 @@
               <a [href]="deployment.deployment.openShiftConsoleUrl" target="openshift" title="View this Deployment in the OpenShift Console">OpenShift Console</a>
             </li>
             <li>
-              <a [routerLink]="[deployment.id, 'edit']">Edit</a>
+              <a [routerLink]="[prefixPath(deployment.id), 'edit']">Edit</a>
             </li>
             <li class="divider"></li>
             <li>
@@ -44,7 +44,7 @@
         <div class='list-view-pf-body'>
           <div class='list-view-pf-description'>
             <div class='list-group-item-heading'>
-              <a [routerLink]="[deployment.id]" class="card-title" title="view deployment">{{ deployment.name }}</a>
+              <a [routerLink]="[prefixPath(deployment.id)]" class="card-title" title="view deployment">{{ deployment.name }}</a>
             </div>
             <div class='list-group-item-text'>
               <span class='open-service-icon'>

--- a/src/app/kubernetes/ui/deployment/list/list.deployment.component.ts
+++ b/src/app/kubernetes/ui/deployment/list/list.deployment.component.ts
@@ -1,7 +1,7 @@
-import {Component, Input, ViewChild} from "@angular/core";
-import {DeploymentDeleteDialog} from "../delete-dialog/delete-dialog.deployment.component";
-import {DeploymentScaleDialog} from "../scale-dialog/scale-dialog.deployment.component";
-import {DeploymentViews} from '../../../view/deployment.view';
+import { Component, Input, ViewChild } from "@angular/core";
+import { DeploymentDeleteDialog } from "../delete-dialog/delete-dialog.deployment.component";
+import { DeploymentScaleDialog } from "../scale-dialog/scale-dialog.deployment.component";
+import { DeploymentViews } from '../../../view/deployment.view';
 
 @Component({
   selector: 'fabric8-deployments-list',
@@ -13,6 +13,8 @@ export class DeploymentsListComponent {
   @Input() runtimeDeployments: DeploymentViews;
 
   @Input() loading: boolean;
+
+  @Input() prefix: string;
 
   @ViewChild(DeploymentDeleteDialog) deleteDialog: DeploymentDeleteDialog;
 
@@ -27,6 +29,10 @@ export class DeploymentsListComponent {
   openScaleDialog(scaleDeploymentModal, deployment) {
     this.scaleDialog.configure(scaleDeploymentModal, deployment);
     scaleDeploymentModal.open();
+  }
+
+  prefixPath(pathComponent: string) {
+    return (this.prefix ? this.prefix + '/' : '') + pathComponent;
   }
 
 }

--- a/src/app/kubernetes/ui/environment/detail/detail.environment.component.html
+++ b/src/app/kubernetes/ui/environment/detail/detail.environment.component.html
@@ -1,0 +1,4 @@
+<div class="detail-panel">
+  <button (click)="close()" class="btn btn-link"><span class="pficon pficon-close"></span></button>
+  <router-outlet></router-outlet>
+</div>

--- a/src/app/kubernetes/ui/environment/detail/detail.environment.component.scss
+++ b/src/app/kubernetes/ui/environment/detail/detail.environment.component.scss
@@ -1,0 +1,17 @@
+@import '../../../../../assets/stylesheets/base';
+
+//detail panel
+.detail-panel {
+  background: $color-pf-white;
+  position: fixed;
+  left: auto;
+  top: em(34);
+  right: 0;
+  bottom: 0;
+  width: 50%;
+  min-width: em(250);
+  z-index: 100;
+  padding: em(20) 0;
+  border-left: 1px solid darken($color-pf-white, 20%);
+  overflow-y: scroll;
+}

--- a/src/app/kubernetes/ui/environment/detail/detail.environment.component.ts
+++ b/src/app/kubernetes/ui/environment/detail/detail.environment.component.ts
@@ -1,0 +1,28 @@
+import { Router } from '@angular/router';
+import { ParentLinkFactory } from './../../../../common/parent-link-factory';
+import { Component } from '@angular/core';
+@Component({
+  selector: 'fabric8-environments-detail',
+  templateUrl: './detail.environment.component.html',
+  styleUrls: ['./detail.environment.component.scss'],
+})
+export class EnvironmentDetailComponent {
+
+  parentLink: string;
+
+  constructor(
+    parentLinkFactory: ParentLinkFactory,
+    private router: Router
+  ) {
+    this.parentLink = parentLinkFactory.parentLink;
+
+  }
+
+  close() {
+    let url = this.router.url;
+    let terminator = 'environments';
+    let newurl = url.slice(0, url.lastIndexOf(terminator) + terminator.length);
+    this.router.navigateByUrl(newurl);
+  }
+
+}

--- a/src/app/kubernetes/ui/environment/detail/detail.environment.spec.ts
+++ b/src/app/kubernetes/ui/environment/detail/detail.environment.spec.ts
@@ -1,0 +1,60 @@
+import { TestAppModule } from './../../../../app.test.module';
+/* tslint:disable:no-unused-variable */
+import {async, ComponentFixture, TestBed} from "@angular/core/testing";
+import {EnvironmentDetailComponent} from "./detail.environment.component";
+import {Fabric8CommonModule} from "../../../../common/common.module";
+import {RouterTestingModule} from "@angular/router/testing";
+import {MomentModule} from "angular2-moment";
+import {EnvironmentDeleteDialog} from "../delete-dialog/delete-dialog.environment.component";
+import {KubernetesStoreModule} from "../../../kubernetes.store.module";
+import {ModalModule} from "ng2-modal";
+import {FormsModule} from "@angular/forms";
+import {RequestOptions, BaseRequestOptions, Http} from "@angular/http";
+import {RestangularModule} from "ng2-restangular";
+import {MockBackend} from "@angular/http/testing";
+import {KubernetesComponentsModule} from "../../../components/components.module";
+
+describe('EnvironmentDetailComponent', () => {
+  let component: EnvironmentDetailComponent;
+  let fixture: ComponentFixture<EnvironmentDetailComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        Fabric8CommonModule,
+        FormsModule,
+        MomentModule,
+        ModalModule,
+        RouterTestingModule.withRoutes([]),
+        RestangularModule.forRoot(),
+        KubernetesStoreModule,
+        KubernetesComponentsModule,
+        TestAppModule
+      ],
+      declarations: [
+        EnvironmentDetailComponent,
+        EnvironmentDeleteDialog,
+      ],
+      providers: [
+        MockBackend,
+        { provide: RequestOptions, useClass: BaseRequestOptions },
+        {
+          provide: Http, useFactory: (backend, options) => {
+            return new Http(backend, options);
+          }, deps: [MockBackend, RequestOptions],
+        },
+      ],
+    })
+      .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(EnvironmentDetailComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/kubernetes/ui/environment/environment-routing.module.ts
+++ b/src/app/kubernetes/ui/environment/environment-routing.module.ts
@@ -1,0 +1,48 @@
+import { EnvironmentDetailComponent } from './detail/detail.environment.component';
+import { DeploymentModule } from './../deployment/deployment.module';
+import { ConfigMapStore } from './../../store/configmap.store';
+import { NamespaceStore } from './../../store/namespace.store';
+
+import { NgModule } from '@angular/core';
+import { DropdownConfig, DropdownModule } from 'ng2-bootstrap';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { RouterModule, Routes } from '@angular/router';
+import { ModalModule } from 'ng2-modal';
+import { ToolbarModule, TreeListModule } from 'ngx-widgets';
+import { TreeModule } from 'angular2-tree-component';
+import { Fabric8CommonModule } from '../../../common/common.module';
+import { MomentModule } from 'angular2-moment';
+import { KubernetesComponentsModule } from '../../components/components.module';
+import { ConfigMapService } from '../../service/configmap.service';
+import { NamespaceScope } from '../../service/namespace.scope';
+import { NamespaceService } from '../../service/namespace.service';
+import { EnvironmentListPageComponent } from './list-page/list-page.environment.component';
+import { EnvironmentListComponent } from './list/list.environment.component';
+import { EnvironmentListToolbarComponent } from './list-toolbar/list-toolbar.environment.component';
+
+const routes: Routes = [
+  {
+    path: '',
+    component: EnvironmentListPageComponent,
+    children: [
+      { path: 'namespaces/:namespace/configmaps', component: EnvironmentDetailComponent, loadChildren: './../configmap/configmap.module#ConfigMapModule' },
+      { path: 'namespaces/:namespace/deployments', component: EnvironmentDetailComponent, loadChildren: './../deployment/deployment.module#DeploymentModule' },
+      { path: 'namespaces/:namespace/events', component: EnvironmentDetailComponent, loadChildren: './../event/event.module#EventModule' },
+      { path: 'namespaces/:namespace/replicasets', component: EnvironmentDetailComponent, loadChildren: './../replicaset/replicaset.module#ReplicaSetModule' },
+      { path: 'namespaces/:namespace/pods', component: EnvironmentDetailComponent, loadChildren: './../pod/pod.module#PodModule' },
+      { path: 'namespaces/:namespace/services', component: EnvironmentDetailComponent, loadChildren: './../service/service.module#ServiceModule' }
+    ]
+  },
+];
+
+@NgModule({
+  imports: [
+    RouterModule.forChild(routes),
+  ],
+  exports: [
+    RouterModule,
+  ],
+})
+export class EnvironmentRoutingModule {
+}

--- a/src/app/kubernetes/ui/environment/environment.module.ts
+++ b/src/app/kubernetes/ui/environment/environment.module.ts
@@ -1,0 +1,72 @@
+import { EnvironmentDetailComponent } from './detail/detail.environment.component';
+import { ServiceModule } from './../service/service.module';
+import { ServicesListComponent } from './../service/list/list.service.component';
+import { ReplicaSetModule } from './../replicaset/replicaset.module';
+import { PodModule } from './../pod/pod.module';
+import { EventModule } from './../event/event.module';
+import { ConfigMapModule } from './../configmap/configmap.module';
+import { EnvironmentRoutingModule } from './environment-routing.module';
+import { DeploymentModule } from './../deployment/deployment.module';
+import { ConfigMapStore } from './../../store/configmap.store';
+import { NamespaceStore } from './../../store/namespace.store';
+
+import {NgModule} from '@angular/core';
+import {DropdownConfig, DropdownModule} from 'ng2-bootstrap';
+import {CommonModule} from '@angular/common';
+import {FormsModule} from '@angular/forms';
+import {RouterModule, Routes} from '@angular/router';
+import {ModalModule} from 'ng2-modal';
+import { ToolbarModule, TreeListModule } from 'ngx-widgets';
+import { TreeModule } from 'angular2-tree-component';
+import {Fabric8CommonModule} from '../../../common/common.module';
+import {MomentModule} from 'angular2-moment';
+import {KubernetesComponentsModule} from '../../components/components.module';
+import {ConfigMapService} from '../../service/configmap.service';
+import {NamespaceScope} from '../../service/namespace.scope';
+import {NamespaceService} from '../../service/namespace.service';
+import { EnvironmentListPageComponent } from './list-page/list-page.environment.component';
+import { EnvironmentListComponent } from './list/list.environment.component';
+import { EnvironmentListToolbarComponent } from './list-toolbar/list-toolbar.environment.component';
+
+@NgModule({
+  imports: [
+    CommonModule,
+    DropdownModule,
+    FormsModule,
+    ModalModule,
+    MomentModule,
+    RouterModule,
+    Fabric8CommonModule,
+    KubernetesComponentsModule,
+    ToolbarModule,
+    TreeListModule,
+    TreeModule,
+    // Our Routing MUST go before the other Kuberenetes UI modules, so our routes take precedence
+    EnvironmentRoutingModule,
+    DeploymentModule,
+    ConfigMapModule,
+    EventModule,
+    PodModule,
+    ReplicaSetModule,
+    ServiceModule,
+  ],
+  declarations: [
+    EnvironmentListPageComponent,
+    EnvironmentListToolbarComponent,
+    EnvironmentListComponent,
+    EnvironmentDetailComponent,
+  ],
+  providers: [
+    DropdownConfig,
+    NamespaceStore,
+    ConfigMapService,
+    ConfigMapStore,
+    NamespaceScope,
+    NamespaceService,
+  ],
+  exports: [
+    EnvironmentListPageComponent,
+  ],
+})
+export class EnvironmentModule {
+}

--- a/src/app/kubernetes/ui/environment/list-page/list-page.environment.component.html
+++ b/src/app/kubernetes/ui/environment/list-page/list-page.environment.component.html
@@ -1,0 +1,7 @@
+<div class="container-fluid">
+  <div class='environments list'>
+    <fabric8-environments-list-toolbar></fabric8-environments-list-toolbar>
+    <fabric8-environments-list [environments]="environments | async" [loading]="loading | async"></fabric8-environments-list>
+  </div>
+</div>
+<router-outlet></router-outlet>

--- a/src/app/kubernetes/ui/environment/list-page/list-page.environment.component.ts
+++ b/src/app/kubernetes/ui/environment/list-page/list-page.environment.component.ts
@@ -1,0 +1,262 @@
+import { Service } from './../../../model/service.model';
+import { ReplicaSet } from './../../../model/replicaset.model';
+import { Pod } from './../../../model/pod.model';
+import { Event } from './../../../model/event.model';
+import { ConfigMap } from './../../../model/configmap.model';
+import { DeploymentConfig } from './../../../model/deploymentconfig.model';
+import { KubernetesResource } from './../../../model/kubernetesresource.model';
+import { Environment, Space } from './../../../model/space.model';
+import { Params } from '@angular/router';
+import { BehaviorSubject, ConnectableObservable, Observable, Subject } from 'rxjs';
+import { ServiceService } from './../../../service/service.service';
+import { ReplicaSetService } from './../../../service/replicaset.service';
+import { PodService } from './../../../service/pod.service';
+import { EventService } from './../../../service/event.service';
+import { ConfigMapService } from './../../../service/configmap.service';
+import { DeploymentConfigService } from './../../../service/deploymentconfig.service';
+import { NamespacedResourceService } from '../../../service/namespaced.resource.service';
+import { ActivatedRoute } from '@angular/router';
+import { SpaceStore } from './../../../store/space.store';
+import { Component, OnInit } from "@angular/core";
+
+export let KINDS: Kind[] = [
+  {
+    name: "ConfigMap",
+    path: "configmaps",
+  },
+  {
+    name: "Deployment",
+    path: "deployments",
+  },
+  {
+    name: "Event",
+    path: "events",
+  },
+  {
+    name: "Pod",
+    path: "pods",
+  },
+  {
+    name: "ReplicaSet",
+    path: "replicasets",
+  },
+  {
+    name: "Service",
+    path: "services",
+  },
+];
+
+class EnvironmentEntry {
+  environment: Environment;
+  kinds: KindNode[];
+  loading: boolean;
+}
+
+class Kind {
+  name: string;
+  path: string;
+}
+
+class KindNode {
+  title: Subject<string>;
+  environment: Environment;
+  kind: Kind;
+  children: [
+    {
+      loading: Observable<boolean>,
+      data: Observable<any[]>,
+    }
+  ];
+}
+
+@Component({
+  host: {
+    'class': "app-component flex-container in-column-direction flex-grow-1"
+  },
+  selector: 'fabric8-environments-list-page',
+  templateUrl: './list-page.environment.component.html',
+  styleUrls: ['./list-page.environment.component.scss'],
+})
+export class EnvironmentListPageComponent implements OnInit {
+
+  environments: ConnectableObservable<EnvironmentEntry[]>;
+  loading: Subject<boolean> = new BehaviorSubject(true);
+  space: ConnectableObservable<Space>;
+
+  constructor(
+    private spaceStore: SpaceStore,
+    private route: ActivatedRoute,
+    private deploymentConfigService: DeploymentConfigService,
+    private configMapService: ConfigMapService,
+    private eventService: EventService,
+    private podService: PodService,
+    private replicaSetService: ReplicaSetService,
+    private serviceService: ServiceService,
+  ) {
+  }
+
+  ngOnInit() {
+    this.space = this.route.params.pluck<Params, string>('space')
+      .map((id) => this.spaceStore.load(id))
+      .switchMap(() => this.spaceStore.resource.distinctUntilChanged())
+      // Wait 200ms before publishing an empty value - it's probably not empty but it might be!
+      .debounce(space => (space ? Observable.interval(0) : Observable.interval(200)))
+      .publish();
+    this.space.subscribe(space => console.log('spaces', space));
+    let kindPaths = Object.keys(KINDS).map(key => KINDS[key].path);
+    this.environments = this.route.params
+      .pluck<Params, string>('label')
+      .switchMap(label => this.space
+        .map(space => space.environments)
+        .map(environments => environments.map(environment => ({
+          environment: environment,
+          kinds: KINDS.map(kind => {
+            // Give it a default title
+            let title = new BehaviorSubject(`${kind.name}s`);
+            let loading = new BehaviorSubject(true);
+            return {
+              environment: environment,
+              kind: kind,
+              title: title,
+              children: [
+                {
+                  loading: loading,
+                  data: this.getList(kind.path, environment)
+                    // Update the title with the number of objects
+                    .distinctUntilChanged()
+                    .map(arr => {
+                      if (label) {
+                        return arr.filter(val => {
+                          return val.labels['space'] === label;
+                        });
+                      } else {
+                        return arr;
+                      }
+                    })
+                    .do(arr => title.next(`${arr.length} ${kind.name}${arr.length === 1 ? '' : 's'}`))
+                    .do(() => loading.next(false)),
+                },
+              ],
+            } as KindNode;
+          }),
+        })),
+      ))
+      .do(arr => console.log('arr', arr))
+      // Wait 200ms before publishing an empty value - it's probably not empty but it might be!
+      .debounce(arr => (arr.length > 0 ? Observable.interval(0) : Observable.interval(200)))
+      .do(() => this.loading.next(false))
+      .publish();
+
+    this.environments.subscribe(node => {
+      console.log('env', node);
+    });
+    this.environments.connect();
+    this.space.connect();
+  }
+
+  private getList(kind: string, environment: Environment): Observable<KubernetesResource[]> {
+    let namespace = environment.namespace.name;
+    switch (kind) {
+      case 'deployments':
+        return this.listAndWatch(this.deploymentConfigService, namespace, DeploymentConfig);
+      case 'configmaps':
+        return this.listAndWatch(this.configMapService, namespace, ConfigMap);
+      case 'events':
+        return this.listAndWatch(this.eventService, namespace, Event);
+      case 'pods':
+        return this.listAndWatch(this.podService, namespace, Pod);
+      case 'replicasets':
+        return this.listAndWatch(this.replicaSetService, namespace, ReplicaSet);
+      case 'services':
+        return this.listAndWatch(this.serviceService, namespace, Service);
+      default:
+        return Observable.empty();
+    }
+  }
+
+  private listAndWatch<T extends KubernetesResource, L extends Array<T>>(service: NamespacedResourceService<T, L>, namespace: string, type: { new (): T; }) {
+    return Observable.combineLatest(
+      service.list(namespace),
+      Observable.onErrorResumeNext(service.watchNamepace(namespace).dataStream),
+      (list, msg) => this.combineListAndWatchEvent(list, msg, service, type, namespace)
+    );
+  }
+
+  /**
+   * Lets combine the web socket events with the latest list
+   */
+  protected combineListAndWatchEvent<T extends KubernetesResource, L extends Array<T>>(array: L, msg: any, service: NamespacedResourceService<T, L>, type: { new (): T; }, namespace: string): L {
+    // lets process the added /updated / removed
+    if (msg instanceof MessageEvent) {
+      let me = msg as MessageEvent;
+      let data = me.data;
+      if (data) {
+        var json = JSON.parse(data);
+        if (json) {
+          let type = json.type;
+          let resource = json.object;
+          if (type && resource) {
+            switch (type) {
+              case "ADDED":
+                return this.upsertItem(array, resource, service, type);
+              case "MODIFIED":
+                return this.upsertItem(array, resource, service, type);
+              case "DELETED":
+                return this.deleteItemFromArray(array, resource);
+              default:
+                console.log("Unknown WebSocket event type " + type + " for " + resource + " on " + service.serviceUrl + '/' + namespace);
+            }
+          }
+        }
+      }
+    }
+    return array;
+  }
+
+  protected upsertItem<T extends KubernetesResource, L extends Array<T>>(array: L, resource: any, service: NamespacedResourceService<T, L>, type: { new (): T; }): L {
+    let n = this.nameOfResource(resource);
+    if (array && n) {
+      for (let i = 0; i < array.length; i++) {
+        let item = array[i];
+        var name = item.name;
+        if (name && name === n) {
+          item.setResource(resource);
+          //console.log("Updated item " + n);
+          return array;
+        }
+      }
+
+      // now lets add the new item!
+      let item = new type();
+      item.setResource(resource);
+      // lets add the Restangular crack
+      item = service.restangularize(item);
+      array.push(item);
+      //console.log("Added new item " + n);
+    }
+    return array;
+  }
+
+
+  protected deleteItemFromArray<T extends KubernetesResource, L extends Array<T>>(array: L, resource: any): L {
+    let n = this.nameOfResource(resource);
+    if (array && n) {
+      for (var i = 0; i < array.length; i++) {
+        let item = array[i];
+        var name = item.name;
+        if (name && name === n) {
+          array.splice(i, 1);
+        }
+      }
+    }
+    return array;
+  }
+
+
+  nameOfResource(resource: any) {
+    let obj = resource || {};
+    let metadata = obj.metadata || {};
+    return metadata.name || "";
+  }
+
+}

--- a/src/app/kubernetes/ui/environment/list-page/list-page.environment.spec.ts
+++ b/src/app/kubernetes/ui/environment/list-page/list-page.environment.spec.ts
@@ -1,0 +1,64 @@
+import { TestAppModule } from './../../../../app.test.module';
+/* tslint:disable:no-unused-variable */
+import {async, ComponentFixture, TestBed} from "@angular/core/testing";
+import {RouterTestingModule} from "@angular/router/testing";
+import {MockBackend} from "@angular/http/testing";
+import {RequestOptions, BaseRequestOptions, Http} from "@angular/http";
+import {RestangularModule} from "ng2-restangular";
+import {EnvironmentListPage} from "./list-page.environment.component";
+import {EnvironmentListComponent} from "../list/list.environment.component";
+import {EnvironmentListToolbarComponent} from "../list-toolbar/list-toolbar.environment.component";
+import {Fabric8CommonModule} from "../../../../common/common.module";
+import {KubernetesStoreModule} from "../../../kubernetes.store.module";
+import {ModalModule} from "ng2-modal";
+import {MomentModule} from "angular2-moment";
+import {EnvironmentDeleteDialog} from "../delete-dialog/delete-dialog.environment.component";
+import {FormsModule} from "@angular/forms";
+import {KubernetesComponentsModule} from "../../../components/components.module";
+
+describe('EnvironmentListPage', () => {
+  let component: EnvironmentListPage;
+  let fixture: ComponentFixture<EnvironmentListPage>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        Fabric8CommonModule,
+        RouterTestingModule.withRoutes([]),
+        RestangularModule.forRoot(),
+        FormsModule,
+        MomentModule,
+        ModalModule,
+        KubernetesStoreModule,
+        KubernetesComponentsModule,
+        TestAppModule
+      ],
+      declarations: [
+        EnvironmentListPage,
+        EnvironmentListComponent,
+        EnvironmentListToolbarComponent,
+        EnvironmentDeleteDialog,
+      ],
+      providers: [
+        MockBackend,
+        { provide: RequestOptions, useClass: BaseRequestOptions },
+        {
+          provide: Http, useFactory: (backend, options) => {
+            return new Http(backend, options);
+          }, deps: [MockBackend, RequestOptions],
+        },
+      ],
+    })
+      .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(EnvironmentListPage);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/kubernetes/ui/environment/list-toolbar/list-toolbar.environment.component.html
+++ b/src/app/kubernetes/ui/environment/list-toolbar/list-toolbar.environment.component.html
@@ -1,0 +1,51 @@
+<div class='row toolbar-pf'>
+  <div class='col-sm-12'>
+    <div class='toolbar-pf-actions'>
+
+      <!-- Toolbar: Search -->
+
+      <div class='form-group toolbar-pf-filter search'>
+        <label class='sr-only'>Name</label>
+        <div class='input-group'>
+          <div class='input-group-btn' dropdown>
+            <button type='button' class='btn btn-default' aria-haspopup='true' aria-expanded='false' dropdownToggle>Name&nbsp;
+                <span class='caret'></span>
+              </button>
+            <ul role="menu" dropdownMenu>
+              <li>
+                <a href='#'>Name</a>
+              </li>
+              <li>
+                <a href='#'>Type</a>
+              </li>
+            </ul>
+          </div>
+          <input type='text' class='form-control' placeholder='Filter By Name...' autocomplete='off' id='filterInput'>
+        </div>
+      </div>
+
+      <!-- Toolbar: Sort -->
+
+      <div class='form-group sort'>
+        <div class='dropdown btn-group' dropdown>
+          <button type='button' class='btn btn-default' aria-haspopup='true' aria-expanded='false' dropdownToggle>Name&nbsp;
+              <span class='caret'></span>
+            </button>
+          <ul role="menu" dropdownMenu>
+            <li>
+              <a href='#'>Name</a>
+            </li>
+            <li>
+              <a href='#'>Type</a>
+            </li>
+          </ul>
+        </div>
+        <button class='btn btn-link' type='button'>
+            <span class='fa fa-sort-alpha-asc'></span>
+          </button>
+      </div>
+    </div>
+  </div>
+  <!-- /col -->
+</div>
+<!-- /row -->

--- a/src/app/kubernetes/ui/environment/list-toolbar/list-toolbar.environment.component.scss
+++ b/src/app/kubernetes/ui/environment/list-toolbar/list-toolbar.environment.component.scss
@@ -1,0 +1,5 @@
+.toolbar-pf {
+  .form-group.sort {
+    border-right: 0 !important;
+  }
+}

--- a/src/app/kubernetes/ui/environment/list-toolbar/list-toolbar.environment.component.ts
+++ b/src/app/kubernetes/ui/environment/list-toolbar/list-toolbar.environment.component.ts
@@ -1,0 +1,10 @@
+import {Component} from "@angular/core";
+
+@Component({
+  selector: 'fabric8-environments-list-toolbar',
+  templateUrl: './list-toolbar.environment.component.html',
+  styleUrls: ['./list-toolbar.environment.component.scss'],
+})
+export class EnvironmentListToolbarComponent {
+
+}

--- a/src/app/kubernetes/ui/environment/list-toolbar/list-toolbar.environment.spec.ts
+++ b/src/app/kubernetes/ui/environment/list-toolbar/list-toolbar.environment.spec.ts
@@ -1,0 +1,27 @@
+/* tslint:disable:no-unused-variable */
+import {async, ComponentFixture, TestBed} from "@angular/core/testing";
+import {RouterTestingModule} from "@angular/router/testing";
+import {EnvironmentListToolbarComponent} from "./list-toolbar.environment.component";
+
+describe('EnvironmentListToolbarComponent', () => {
+  let component: EnvironmentListToolbarComponent;
+  let fixture: ComponentFixture<EnvironmentListToolbarComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      imports: [RouterTestingModule.withRoutes([])],
+      declarations: [EnvironmentListToolbarComponent],
+    })
+      .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(EnvironmentListToolbarComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/kubernetes/ui/environment/list/list.environment.component.html
+++ b/src/app/kubernetes/ui/environment/list/list.environment.component.html
@@ -1,0 +1,67 @@
+<fabric8-loading [loading]="loading">
+  <div id="environments" class="content container">
+    <div class="environment" *ngFor="let e of environments">
+      <h2>{{e.environment.name}}</h2>
+      <small>
+        <!-- TODO HACK this needs to be dynamic! -->
+        <a href="https://console.free-int.openshift.com/console/project/{{e.environment.namespaceName}}">See more in OpenShift console <span class="fa fa-external-link"></span></a>
+      </small>
+
+      <alm-tree-list #treeList [listTemplate]="treeListTemplate" [nodes]="e.kinds" [options]="options" [showExpander]="false">
+        <template #treeListTemplate let-node="node" let-index="index">
+          <div [ngSwitch]="node.parent?.data?.kind?.path?.toLowerCase()">
+            <div *ngSwitchCase="'configmaps'" class="environment-listing">
+              <alm-tree-list-item [node]="node" [template]="treeListItemTemplate">
+                <template #treeListItemTemplate>
+                  <fabric8-configmaps-list [configmaps]="node.data.data | async" [loading]="node.data.loading | async" [prefix]="'namespaces/' + e.environment.namespaceName + '/configmaps'"></fabric8-configmaps-list>
+                </template>
+              </alm-tree-list-item>
+            </div>
+            <div *ngSwitchCase="'deployments'" class="environment-listing">
+              <alm-tree-list-item [node]="node" [template]="treeListItemTemplate">
+                <template #treeListItemTemplate>
+                  <fabric8-deployments-list [runtimeDeployments]="node.data.data | async" [loading]="node.data.loading | async" [prefix]="'namespaces/' + e.environment.namespaceName + '/deployments'"></fabric8-deployments-list>
+                </template>
+              </alm-tree-list-item>
+            </div>
+            <div *ngSwitchCase="'events'" class="environment-listing">
+              <alm-tree-list-item [node]="node" [template]="treeListItemTemplate">
+                <template #treeListItemTemplate>
+                  <fabric8-events-list [events]="node.data.data | async" [loading]="node.data.loading | async" [prefix]="'namespaces/' + e.environment.namespaceName + '/events'"></fabric8-events-list>
+                </template>
+              </alm-tree-list-item>
+            </div>
+            <div *ngSwitchCase="'pods'" class="environment-listing">
+              <alm-tree-list-item [node]="node" [template]="treeListItemTemplate">
+                <template #treeListItemTemplate>
+                  <fabric8-pods-list [pods]="node.data.data | async" [loading]="node.data.loading | async" [prefix]="'namespaces/' + e.environment.namespaceName + '/pods'"></fabric8-pods-list>
+                </template>
+              </alm-tree-list-item>
+            </div>
+            <div *ngSwitchCase="'replicasets'" class="environment-listing">
+              <alm-tree-list-item [node]="node" [template]="treeListItemTemplate">
+                <template #treeListItemTemplate>
+                  <fabric8-replicasets-list [runtimeReplicaSets]="node.data.data | async" [loading]="node.data.loading | async" [prefix]="'namespaces/' + e.environment.namespaceName + '/replicaSets'"></fabric8-replicasets-list>
+                </template>
+              </alm-tree-list-item>
+            </div>
+            <div *ngSwitchCase="'services'" class="environment-listing">
+              <alm-tree-list-item [node]="node" [template]="treeListItemTemplate">
+                <template #treeListItemTemplate>
+                  <fabric8-services-list [services]="node.data.data | async" [loading]="node.data.loading | async" [prefix]="'namespaces/' + e.environment.namespaceName + '/events'"></fabric8-services-list>
+                </template>
+              </alm-tree-list-item>
+            </div>
+            <div *ngSwitchDefault>
+              <alm-tree-list-item [node]="node" [template]="treeListItemTemplate">
+                <template #treeListItemTemplate>
+                  <span title="{{node.data.subTitle}}">{{ node.data.title | async }}</span>
+                </template>
+              </alm-tree-list-item>
+            </div>
+          </div>
+        </template>
+      </alm-tree-list>
+    </div>
+  </div>
+</fabric8-loading>

--- a/src/app/kubernetes/ui/environment/list/list.environment.component.ts
+++ b/src/app/kubernetes/ui/environment/list/list.environment.component.ts
@@ -1,0 +1,61 @@
+import { ServiceService } from './../../../service/service.service';
+import { Params } from '@angular/router';
+import { ActivatedRoute } from '@angular/router';
+import { SpaceStore } from './../../../store/space.store';
+import { Deployments } from './../../../model/deployment.model';
+import { Component, Input, ViewChild } from "@angular/core";
+
+import { Observable, ConnectableObservable, Subject, BehaviorSubject } from 'rxjs';
+
+import {
+  TreeNode,
+  TREE_ACTIONS,
+  IActionMapping
+} from 'angular2-tree-component';
+
+import { ParentLinkFactory } from "../../../../common/parent-link-factory";
+import { CompositeDeploymentStore } from './../../../store/compositedeployment.store';
+import { ServiceStore } from './../../../store/service.store';
+import { createDeploymentViews } from '../../../view/deployment.view';
+import { ReplicaSetService } from './../../../service/replicaset.service';
+import { PodService } from './../../../service/pod.service';
+import { EventService } from './../../../service/event.service';
+import { ConfigMapService } from './../../../service/configmap.service';
+import { DeploymentConfigService } from './../../../service/deploymentconfig.service';
+import { DeploymentConfigs } from './../../../model/deploymentconfig.model';
+import { DeploymentService } from './../../../service/deployment.service';
+import { Space, Environment } from './../../../model/space.model';
+
+@Component({
+  selector: 'fabric8-environments-list',
+  templateUrl: './list.environment.component.html',
+  styleUrls: ['./list.environment.component.scss'],
+})
+export class EnvironmentListComponent {
+
+  // See: https://angular2-tree.readme.io/docs/options
+  options = {
+    actionMapping: {
+      mouse: {
+        click: (tree, node, $event) => {
+          TREE_ACTIONS.TOGGLE_EXPANDED(tree, node, $event);
+        },
+      },
+    },
+    allowDrag: false,
+    isExpandedField: 'expanded',
+  };
+
+  parentLink: string;
+
+  @Input() loading: boolean;
+  @Input() environments: any;
+
+  constructor(
+    parentLinkFactory: ParentLinkFactory,
+  ) {
+    this.parentLink = parentLinkFactory.parentLink;
+
+  }
+
+}

--- a/src/app/kubernetes/ui/environment/list/list.environment.spec.ts
+++ b/src/app/kubernetes/ui/environment/list/list.environment.spec.ts
@@ -1,0 +1,60 @@
+import { TestAppModule } from './../../../../app.test.module';
+/* tslint:disable:no-unused-variable */
+import {async, ComponentFixture, TestBed} from "@angular/core/testing";
+import {EnvironmentListComponent} from "./list.environment.component";
+import {Fabric8CommonModule} from "../../../../common/common.module";
+import {RouterTestingModule} from "@angular/router/testing";
+import {MomentModule} from "angular2-moment";
+import {EnvironmentDeleteDialog} from "../delete-dialog/delete-dialog.environment.component";
+import {KubernetesStoreModule} from "../../../kubernetes.store.module";
+import {ModalModule} from "ng2-modal";
+import {FormsModule} from "@angular/forms";
+import {RequestOptions, BaseRequestOptions, Http} from "@angular/http";
+import {RestangularModule} from "ng2-restangular";
+import {MockBackend} from "@angular/http/testing";
+import {KubernetesComponentsModule} from "../../../components/components.module";
+
+describe('EnvironmentListComponent', () => {
+  let component: EnvironmentListComponent;
+  let fixture: ComponentFixture<EnvironmentListComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        Fabric8CommonModule,
+        FormsModule,
+        MomentModule,
+        ModalModule,
+        RouterTestingModule.withRoutes([]),
+        RestangularModule.forRoot(),
+        KubernetesStoreModule,
+        KubernetesComponentsModule,
+        TestAppModule
+      ],
+      declarations: [
+        EnvironmentListComponent,
+        EnvironmentDeleteDialog,
+      ],
+      providers: [
+        MockBackend,
+        { provide: RequestOptions, useClass: BaseRequestOptions },
+        {
+          provide: Http, useFactory: (backend, options) => {
+            return new Http(backend, options);
+          }, deps: [MockBackend, RequestOptions],
+        },
+      ],
+    })
+      .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(EnvironmentListComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/kubernetes/ui/event/event.module.ts
+++ b/src/app/kubernetes/ui/event/event.module.ts
@@ -42,6 +42,7 @@ const routes: Routes = [
   ],
   exports: [
     ModalModule,
+    EventsListComponent,
   ],
   providers: [
     DropdownConfig

--- a/src/app/kubernetes/ui/event/list/list.event.component.html
+++ b/src/app/kubernetes/ui/event/list/list.event.component.html
@@ -12,7 +12,7 @@
             </button>
           <ul class='dropdown-menu-right' aria-labelledby='dropdownKebabRight9' role="menu" dropdownMenu>
             <li>
-              <a [routerLink]="[event.id, 'edit']">Edit</a>
+              <a [routerLink]="[pathPrefix(event.id), 'edit']">Edit</a>
             </li>
           </ul>
         </div>
@@ -35,7 +35,7 @@
         <div class='list-view-pf-body'>
           <div class='list-view-pf-description'>
             <div class='list-group-item-heading'>
-              <a [routerLink]="[event.id]" class="card-title" title="view event">{{ event.name }}</a>
+              <a [routerLink]="[pathPrefix(event.id)]" class="card-title" title="view event">{{ event.name }}</a>
             </div>
             <div class='list-group-item-text' title="message">
               {{event?.resource?.message}}

--- a/src/app/kubernetes/ui/event/list/list.event.component.ts
+++ b/src/app/kubernetes/ui/event/list/list.event.component.ts
@@ -11,4 +11,10 @@ export class EventsListComponent {
   @Input() events: Events;
 
   @Input() loading: boolean;
+
+  @Input() prefix: string;
+
+  prefixPath(pathComponent: string) {
+    return (this.prefix ? this.prefix + '/' : '') + pathComponent;
+  }
 }

--- a/src/app/kubernetes/ui/pod/list/list.pod.component.html
+++ b/src/app/kubernetes/ui/pod/list/list.pod.component.html
@@ -18,7 +18,7 @@
               <a [href]="consoleTerminalUrl(pod)" target="openshift">Terminal</a>
             </li>
             <li>
-              <a [routerLink]="[pod.id, 'edit']">Edit</a>
+              <a [routerLink]="[ prefixPath(pod.id), 'edit']">Edit</a>
             </li>
             <li class="divider"></li>
             <li>
@@ -35,7 +35,7 @@
         <div class='list-view-pf-body'>
           <div class='list-view-pf-description'>
             <div class='list-group-item-heading'>
-              <a [routerLink]="[pod.id]" class="card-title" title="view pod">{{ pod.name }}</a>
+              <a [routerLink]="[prefixPath(pod.id)]" class="card-title" title="view pod">{{ pod.name }}</a>
             </div>
             <div class='list-group-item-text'>
               <span class="" *ngFor='let image of pod.images' title="docker image: {{image}}">

--- a/src/app/kubernetes/ui/pod/list/list.pod.component.ts
+++ b/src/app/kubernetes/ui/pod/list/list.pod.component.ts
@@ -14,6 +14,8 @@ export class PodsListComponent {
 
   @Input() loading: boolean;
 
+  @Input() prefix: string;
+
   @ViewChild(PodDeleteDialog) deleteDialog: PodDeleteDialog;
 
   openDeleteDialog(deletePodModal, pod) {
@@ -34,5 +36,9 @@ export class PodsListComponent {
 
   consoleUrl(pod: Pod): string {
     return openShiftBrowseResourceUrl(pod);
+  }
+
+  prefixPath(pathComponent: string) {
+    return (this.prefix ? this.prefix + '/' : '') + pathComponent;
   }
 }

--- a/src/app/kubernetes/ui/pod/pod.module.ts
+++ b/src/app/kubernetes/ui/pod/pod.module.ts
@@ -57,6 +57,7 @@ const routes: Routes = [
   ],
   exports: [
     ModalModule,
+    PodsListComponent,
   ],
   providers: [
     DropdownConfig

--- a/src/app/kubernetes/ui/replicaset/list/list.replicaset.component.html
+++ b/src/app/kubernetes/ui/replicaset/list/list.replicaset.component.html
@@ -21,7 +21,7 @@
               <a (click)="openScaleDialog(scaleReplicaSetModal, replicaset.replicaset)" title="Scale the number of pods">Scale</a>
             </li>
             <li>
-              <a [routerLink]="[replicaset.id, 'edit']">Edit</a>
+              <a [routerLink]="[pathPrefix(replicaset.id), 'edit']">Edit</a>
             </li>
 
             <li>
@@ -38,7 +38,7 @@
         <div class='list-view-pf-body'>
           <div class='list-view-pf-description'>
             <div class='list-group-item-heading'>
-              <a [routerLink]="[replicaset.id]" class="card-title" title="view replicaset">{{ replicaset.name }}</a>
+              <a [routerLink]="[pathPrefix(replicaset.id)]" class="card-title" title="view replicaset">{{ replicaset.name }}</a>
 
               <span class='open-service-icon'>
                 <a target="replicaset"

--- a/src/app/kubernetes/ui/replicaset/list/list.replicaset.component.ts
+++ b/src/app/kubernetes/ui/replicaset/list/list.replicaset.component.ts
@@ -1,7 +1,7 @@
-import {Component, Input, ViewChild} from "@angular/core";
-import {ReplicaSetDeleteDialog} from "../delete-dialog/delete-dialog.replicaset.component";
-import {ReplicaSetViews} from "../../../view/replicaset.view";
-import {ReplicaSetScaleDialog} from "../scale-dialog/scale-dialog.replicaset.component";
+import { Component, Input, ViewChild } from "@angular/core";
+import { ReplicaSetDeleteDialog } from "../delete-dialog/delete-dialog.replicaset.component";
+import { ReplicaSetViews } from "../../../view/replicaset.view";
+import { ReplicaSetScaleDialog } from "../scale-dialog/scale-dialog.replicaset.component";
 
 @Component({
   selector: 'fabric8-replicasets-list',
@@ -13,6 +13,8 @@ export class ReplicaSetsListComponent {
   @Input() runtimeReplicaSets: ReplicaSetViews;
 
   @Input() loading: boolean;
+
+  @Input() prefix: string;
 
   @ViewChild(ReplicaSetDeleteDialog) deleteDialog: ReplicaSetDeleteDialog;
 
@@ -27,6 +29,10 @@ export class ReplicaSetsListComponent {
   openScaleDialog(scaleReplicaSetModal, replicaset) {
     this.scaleDialog.configure(scaleReplicaSetModal, replicaset);
     scaleReplicaSetModal.open();
+  }
+
+  prefixPath(pathComponent: string) {
+    return (this.prefix ? this.prefix + '/' : '') + pathComponent;
   }
 
 }

--- a/src/app/kubernetes/ui/replicaset/replicaset.module.ts
+++ b/src/app/kubernetes/ui/replicaset/replicaset.module.ts
@@ -59,6 +59,7 @@ const routes: Routes = [
   ],
   exports: [
     ModalModule,
+    ReplicaSetsListComponent,
   ],
   providers: [
     DropdownConfig

--- a/src/app/kubernetes/ui/service/list/list.service.component.html
+++ b/src/app/kubernetes/ui/service/list/list.service.component.html
@@ -15,7 +15,7 @@
               <a [href]="service.openShiftConsoleUrl" target="openshift" title="View this Service in the OpenShift Console">OpenShift Console</a>
             </li>
             <li>
-              <a [routerLink]="[service.id, 'edit']">Edit</a>
+              <a [routerLink]="[pathPrefix(service.id), 'edit']">Edit</a>
             </li>
             <li class="divider"></li>
             <li>
@@ -32,7 +32,7 @@
         <div class='list-view-pf-body'>
           <div class='list-view-pf-description'>
             <div class='list-group-item-heading'>
-              <a [routerLink]="[service.id]" class="card-title" title="view service">{{ service.name }}</a>
+              <a [routerLink]="[pathPrefix(service.id)]" class="card-title" title="view service">{{ service.name }}</a>
             </div>
             <div class='list-group-item-text'>
               <span class='open-service-icon'>

--- a/src/app/kubernetes/ui/service/list/list.service.component.ts
+++ b/src/app/kubernetes/ui/service/list/list.service.component.ts
@@ -1,6 +1,6 @@
-import {Component, Input, ViewChild} from "@angular/core";
-import {ServiceDeleteDialog} from "../delete-dialog/delete-dialog.service.component";
-import {Services} from "../../../model/service.model";
+import { Component, Input, ViewChild } from "@angular/core";
+import { ServiceDeleteDialog } from "../delete-dialog/delete-dialog.service.component";
+import { Services } from "../../../model/service.model";
 
 @Component({
   selector: 'fabric8-services-list',
@@ -13,12 +13,18 @@ export class ServicesListComponent {
 
   @Input() loading: boolean;
 
+  @Input() prefix: string;
+
   @ViewChild(ServiceDeleteDialog) deleteDialog: ServiceDeleteDialog;
 
   openDeleteDialog(deleteServiceModal, service) {
     this.deleteDialog.modal = deleteServiceModal;
     this.deleteDialog.service = service;
     deleteServiceModal.open();
+  }
+
+  prefixPath(pathComponent: string) {
+    return (this.prefix ? this.prefix + '/' : '') + pathComponent;
   }
 
 }

--- a/src/app/kubernetes/ui/service/service.module.ts
+++ b/src/app/kubernetes/ui/service/service.module.ts
@@ -57,6 +57,7 @@ const routes: Routes = [
   ],
   exports: [
     ModalModule,
+    ServicesListComponent,
   ],
   providers: [
     DropdownConfig

--- a/src/app/kubernetes/ui/ui.module.ts
+++ b/src/app/kubernetes/ui/ui.module.ts
@@ -15,6 +15,7 @@ const routes: Routes = [
   { path: 'namespaces/:namespace/services', loadChildren: './service/service.module#ServiceModule' },
   { path: 'namespace', loadChildren: './namespace/namespace.module#NamespaceModule' },
   { path: 'spaces', loadChildren: './space/space.module#SpaceModule' },
+  { path: 'environments', loadChildren: './environment/environment.module#EnvironmentModule'}
 ];
 
 

--- a/tslint.json
+++ b/tslint.json
@@ -105,13 +105,13 @@
     "directive-selector": [
       true,
       "attribute",
-      "ipaas",
+      "fabroic8",
       "camelCase"
     ],
     "component-selector": [
       true,
       "element",
-      "ipaas",
+      "fabric8",
       "kebab-case"
     ],
     "use-input-property-decorator": true,


### PR DESCRIPTION
Initial implementation of new environment page. Includes:

* Listing all environments along with all associated resources
* Websocket support
* Flyovers for all actions that can be completed for all resource kinds
* Filtering on label space if specified
* Support for all actions on all detail pages

Mostly working, but I know of quite a few issues, not least:

* It's using a tree not a compound expanding list as @dlabrecq is working on a angular 2 component for the expanding list which I will later migrate to
* Sometimes it selects the default namespace by mistake (but a number of things do that, I think this is a broader timing problem
* The deployment dialogs aren't working, they select the wrong thing (not deeply investigated)
* The flyover is just appearing and disappearing. @dgutride is investigating compentizing this anyway so I didn't work on this
* A lot of overflow problems with the CSS
* Deleting Pods (and possibly other things) doesn't work as I got something wrong with the types
* There are some z-index problems with the modals

Once we get this merged I will work next on integrating this into fabric8-ui so that i can work out any integration bugs.