### PR TITLE
feat(stack-analysis): introduce the fabric8-stack-analysis-ui npm int…

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
   "dependencies": {
     "@angular/core": "2.4.9",
     "angular-2-local-storage": "1.0.1",
+    "fabric8-stack-analysis-ui": "0.0.3",
     "ngx-base": "1.2.0",
     "ngx-fabric8-wit": "6.15.2",
     "ngx-login-client": "0.6.5",

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -32,6 +32,10 @@ import { authApiUrlProvider } from './shared/auth-api.provider';
 import { ssoApiUrlProvider } from './shared/sso-api.provider';
 import { TokenResolver } from './shared/token.resolver';
 
+// Introduced to prevent the error that comes on click of build tab
+// As fabric8-stack-analysis-ui NPM package that is put there uses this provider
+import {Contexts} from 'ngx-fabric8-wit';
+
 
 export function restangularProviderConfigurer(restangularProvider: any, config: ConfigService) {
   restangularProvider.setBaseUrl(config.getSettings().apiEndpoint);
@@ -61,6 +65,7 @@ export function restangularProviderConfigurer(restangularProvider: any, config: 
   ],
   providers: [
     ConfigService,
+    Contexts,
     DropdownConfig,
     {
       provide: APP_INITIALIZER,

--- a/src/app/kubernetes/ui/pipeline/list/list.pipeline.component.html
+++ b/src/app/kubernetes/ui/pipeline/list/list.pipeline.component.html
@@ -68,6 +68,12 @@
             <div class="mar-top-sm ">
               <a [routerLink]="[pipeline.id, 'history']" class="card-title" title="view pipeline">View History</a>
             </div>
+
+            <!-- Fabric-stack-analysis-ui -->
+            <div class="col-xs-12">
+              <stack-details [stack]="codebases && codebases[0]"></stack-details>
+            </div>
+            <!-- Fabric-stack-analysis-ui -->
           </div>
         </div>
       </div>

--- a/src/app/kubernetes/ui/pipeline/list/list.pipeline.component.ts
+++ b/src/app/kubernetes/ui/pipeline/list/list.pipeline.component.ts
@@ -15,6 +15,14 @@ export class PipelinesListComponent {
 
   @ViewChild(BuildConfigDeleteDialog) deleteDialog: BuildConfigDeleteDialog;
 
+  // This hardcode will be replaced by the information received from the build to trigger the stack analysis
+  public codebases: Array<any> = [
+        {
+        name: 'Pllm',
+        uuid: 'ff59ea91cf264003bc6dc12621c91205'
+        },
+    ];
+
   openDeleteDialog(deleteBuildConfigModal, pipeline) {
     this.deleteDialog.modal = deleteBuildConfigModal;
     this.deleteDialog.buildconfig = pipeline;

--- a/src/app/kubernetes/ui/pipeline/pipeline.module.ts
+++ b/src/app/kubernetes/ui/pipeline/pipeline.module.ts
@@ -23,6 +23,8 @@ import {PipelinesFullHistoryToolbarComponent} from "./full-history-toolbar/full-
 import {PipelinesFullHistoryComponent} from "./full-history/full-history.pipeline.component";
 import {PipelinesFullHistoryPage} from "./full-history-page/full-history-page.pipeline.component";
 
+import {StackDetailsModule} from 'fabric8-stack-analysis-ui';
+
 const routes: Routes = [
   { path: ':id/history', component: PipelinesHistoryPage },
   { path: ':buildConfig/builds', loadChildren: '../build/build.module#BuildModule' },
@@ -35,6 +37,7 @@ const routes: Routes = [
     FormsModule,
     ModalModule,
     MomentModule,
+    StackDetailsModule,
     RouterModule.forChild(routes),
     Fabric8CommonModule,
     KubernetesComponentsModule,


### PR DESCRIPTION
introduce the fabric8-stack-analysis-ui npm into runtime-console.

Changes:
1. list.pipeline.component.html - A placeholder for stack-analysis to sit in the UI
2. list.pipeline.component.ts - A hardcoded build information for now that gives the information to the stack-analysis NPM, which later on has to be replaced with the actual information from the build.
3. pipeline.module.ts - Imports the NPM pacakge.
4. package.json - includes the package name and version
5. app.module.ts - Just for the standalone runtime console to run without breaking on clicking the build tab. Context is being used inside and hence havve to be imported.

Fixes #192.