### PR TITLE
fix(annotations_bayesian): get the url directly from annotations in the build pipeline to pass as input to npm.

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "angular2-moment": "1.3.3",
     "angular2-oauth2": "1.3.10",
     "angular2-websocket": "0.9.1",
-    "fabric8-stack-analysis-ui": "0.1.0",
+    "fabric8-stack-analysis-ui": "0.1.1",
     "ng2-modal": "0.0.25",
     "ngx-base": "1.2.9",
     "ngx-fabric8-wit": "6.17.0",

--- a/src/app/kubernetes/ui/pipeline/build-stage-view/build-stage-view.component.html
+++ b/src/app/kubernetes/ui/pipeline/build-stage-view/build-stage-view.component.html
@@ -32,6 +32,11 @@
               {{stage.durationMillis | amDuration: 'ms'}}
             </div>
           </div>
+            <!-- Fabric-stack-analysis-ui -->
+            <div *ngIf="build && build.annotations && build.annotations['fabric8.io/bayesian.analysisUrl'] && stage.name === 'Build Release' && stage.status === 'SUCCESS'" class="col-xs-12">
+              <stack-details [stack]="build && build.annotations && build.annotations['fabric8.io/bayesian.analysisUrl']"></stack-details>
+            </div>
+            <!-- Fabric-stack-analysis-ui -->
         </div>
       </div>
     </div>

--- a/src/app/kubernetes/ui/pipeline/full-history-page/full-history-page.pipeline.spec.ts
+++ b/src/app/kubernetes/ui/pipeline/full-history-page/full-history-page.pipeline.spec.ts
@@ -17,6 +17,8 @@ import {PipelinesFullHistoryToolbarComponent} from "../full-history-toolbar/full
 import {PipelinesFullHistoryComponent} from "../full-history/full-history.pipeline.component";
 import {BuildStageViewComponent} from "../build-stage-view/build-stage-view.component";
 
+import {StackDetailsModule} from 'fabric8-stack-analysis-ui';
+
 describe('PipelinesFullHistoryPage', () => {
   let component: PipelinesFullHistoryPage;
   let fixture: ComponentFixture<PipelinesFullHistoryPage>;
@@ -33,7 +35,8 @@ describe('PipelinesFullHistoryPage', () => {
         KubernetesStoreModule,
         KubernetesComponentsModule,
         BuildConfigDialogsModule,
-        TestAppModule
+        TestAppModule,
+        StackDetailsModule
       ],
       declarations: [
         BuildStageViewComponent,

--- a/src/app/kubernetes/ui/pipeline/full-history/full-history.pipeline.spec.ts
+++ b/src/app/kubernetes/ui/pipeline/full-history/full-history.pipeline.spec.ts
@@ -15,6 +15,8 @@ import {BuildConfigDialogsModule} from "../../buildconfig/delete-dialog/buildcon
 import {KubernetesComponentsModule} from "../../../components/components.module";
 import {BuildStageViewComponent} from "../build-stage-view/build-stage-view.component";
 
+import {StackDetailsModule} from 'fabric8-stack-analysis-ui';
+
 describe('PipelinesFullHistoryComponent', () => {
   let component: PipelinesFullHistoryComponent;
   let fixture: ComponentFixture<PipelinesFullHistoryComponent>;
@@ -31,7 +33,8 @@ describe('PipelinesFullHistoryComponent', () => {
         KubernetesStoreModule,
         BuildConfigDialogsModule,
         KubernetesComponentsModule,
-        TestAppModule
+        TestAppModule,
+        StackDetailsModule
       ],
       declarations: [
         BuildStageViewComponent,

--- a/src/app/kubernetes/ui/pipeline/history-page/history-page.pipeline.spec.ts
+++ b/src/app/kubernetes/ui/pipeline/history-page/history-page.pipeline.spec.ts
@@ -17,6 +17,8 @@ import {BuildConfigDialogsModule} from "../../buildconfig/delete-dialog/buildcon
 import {KubernetesComponentsModule} from "../../../components/components.module";
 import {BuildStageViewComponent} from "../build-stage-view/build-stage-view.component";
 
+import {StackDetailsModule} from 'fabric8-stack-analysis-ui';
+
 describe('PipelinesHistoryPage', () => {
   let component: PipelinesHistoryPage;
   let fixture: ComponentFixture<PipelinesHistoryPage>;
@@ -33,7 +35,8 @@ describe('PipelinesHistoryPage', () => {
         KubernetesStoreModule,
         KubernetesComponentsModule,
         BuildConfigDialogsModule,
-        TestAppModule
+        TestAppModule,
+        StackDetailsModule
       ],
       declarations: [
         BuildStageViewComponent,

--- a/src/app/kubernetes/ui/pipeline/history/history.pipeline.spec.ts
+++ b/src/app/kubernetes/ui/pipeline/history/history.pipeline.spec.ts
@@ -15,6 +15,8 @@ import {BuildConfigDialogsModule} from "../../buildconfig/delete-dialog/buildcon
 import {KubernetesComponentsModule} from "../../../components/components.module";
 import {BuildStageViewComponent} from "../build-stage-view/build-stage-view.component";
 
+import {StackDetailsModule} from 'fabric8-stack-analysis-ui';
+
 describe('PipelinesHistoryComponent', () => {
   let component: PipelinesHistoryComponent;
   let fixture: ComponentFixture<PipelinesHistoryComponent>;
@@ -31,7 +33,8 @@ describe('PipelinesHistoryComponent', () => {
         KubernetesStoreModule,
         BuildConfigDialogsModule,
         KubernetesComponentsModule,
-        TestAppModule
+        TestAppModule,
+        StackDetailsModule
       ],
       declarations: [
         BuildStageViewComponent,

--- a/src/app/kubernetes/ui/pipeline/list/list.pipeline.component.html
+++ b/src/app/kubernetes/ui/pipeline/list/list.pipeline.component.html
@@ -69,11 +69,6 @@
               <a [routerLink]="[pipeline.id, 'history']" class="card-title" title="view pipeline">View History</a>
             </div>
 
-            <!-- Fabric-stack-analysis-ui -->
-            <div class="col-xs-12">
-              <stack-details [stack]="codebases && codebases[0]"></stack-details>
-            </div>
-            <!-- Fabric-stack-analysis-ui -->
           </div>
         </div>
       </div>

--- a/src/app/kubernetes/ui/pipeline/list/list.pipeline.component.ts
+++ b/src/app/kubernetes/ui/pipeline/list/list.pipeline.component.ts
@@ -14,15 +14,7 @@ export class PipelinesListComponent {
   @Input() loading: boolean;
 
   @ViewChild(BuildConfigDeleteDialog) deleteDialog: BuildConfigDeleteDialog;
-
-  // This hardcode will be replaced by the information received from the build to trigger the stack analysis
-  public codebases: Array<any> = [
-        {
-        name: 'Pllm',
-        uuid: 'ff59ea91cf264003bc6dc12621c91205'
-        },
-    ];
-
+  
   openDeleteDialog(deleteBuildConfigModal, pipeline) {
     this.deleteDialog.modal = deleteBuildConfigModal;
     this.deleteDialog.buildconfig = pipeline;


### PR DESCRIPTION

Changes:

1. Moves the position of the Bayesian stack reports button to inside the pipelines stages - build-stage-view.component.html
2. Removes the existing bayesian includes from list.pipeline.component.html
3. Removes the hardcoded information from list.pipeline.component.ts
4. Made a version change in package.json as both fabric8-stack-analysis-ui and this change have to go in sync.

Fixes #264.