### PR TITLE
fix(treelist): Downgraded angular-tree-component for stability

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "ngx-base": "1.2.9",
     "ngx-fabric8-wit": "6.17.2",
     "ngx-login-client": "0.6.21",
-    "ngx-widgets": "0.13.2",
+    "ngx-widgets": "0.13.4",
     "pluralize": "4.0.0",
     "rxjs": "5.2.0"
   },
@@ -109,7 +109,7 @@
     "angular2-oauth2": "1.3.10",
     "angular2-router-loader": "0.3.5",
     "angular2-template-loader": "0.6.2",
-    "angular-tree-component": "3.2.4",
+    "angular2-tree-component": "2.7.0",
     "angular2-websocket": "0.9.1",
     "autoprefixer": "6.7.7",
     "awesome-typescript-loader": "3.1.2",

--- a/src/app/kubernetes/ui/environment/environment-routing.module.ts
+++ b/src/app/kubernetes/ui/environment/environment-routing.module.ts
@@ -15,7 +15,7 @@ import { FormsModule } from '@angular/forms';
 import { RouterModule, Routes } from '@angular/router';
 import { ModalModule } from 'ng2-modal';
 import { ToolbarModule, TreeListModule } from 'ngx-widgets';
-import { TreeModule } from 'angular-tree-component';
+import { TreeModule } from 'angular2-tree-component';
 import { Fabric8CommonModule } from '../../../common/common.module';
 import { MomentModule } from 'angular2-moment';
 import { KubernetesComponentsModule } from '../../components/components.module';

--- a/src/app/kubernetes/ui/environment/environment.module.ts
+++ b/src/app/kubernetes/ui/environment/environment.module.ts
@@ -17,7 +17,7 @@ import {FormsModule} from '@angular/forms';
 import {RouterModule, Routes} from '@angular/router';
 import {ModalModule} from 'ng2-modal';
 import { ToolbarModule, TreeListModule, SlideOutPanelModule } from 'ngx-widgets';
-import { TreeModule } from 'angular-tree-component';
+import { TreeModule } from 'angular2-tree-component';
 import {Fabric8CommonModule} from '../../../common/common.module';
 import {MomentModule} from 'angular2-moment';
 import {KubernetesComponentsModule} from '../../components/components.module';

--- a/src/app/kubernetes/ui/environment/list-page/list-page.environment.spec.ts
+++ b/src/app/kubernetes/ui/environment/list-page/list-page.environment.spec.ts
@@ -10,7 +10,7 @@ import { EventModule } from './../../event/event.module';
 import { ConfigMapModule } from './../../configmap/configmap.module';
 import { DeploymentModule } from './../../deployment/deployment.module';
 import { EnvironmentRoutingModule } from './../environment-routing.module';
-import { TreeModule } from 'angular-tree-component';
+import { TreeModule } from 'angular2-tree-component';
 import { TreeListModule, SlideOutPanelModule } from 'ngx-widgets';
 import { TestAppModule } from './../../../../app.test.module';
 /* tslint:disable:no-unused-variable */

--- a/src/app/kubernetes/ui/environment/list/list.environment.component.ts
+++ b/src/app/kubernetes/ui/environment/list/list.environment.component.ts
@@ -11,7 +11,7 @@ import {
   TreeNode,
   TREE_ACTIONS,
   IActionMapping
-} from 'angular-tree-component';
+} from 'angular2-tree-component';
 
 import { ParentLinkFactory } from "../../../../common/parent-link-factory";
 import { CompositeDeploymentStore } from './../../../store/compositedeployment.store';

--- a/src/app/kubernetes/ui/environment/list/list.environment.spec.ts
+++ b/src/app/kubernetes/ui/environment/list/list.environment.spec.ts
@@ -8,7 +8,7 @@ import { EventModule } from './../../event/event.module';
 import { ConfigMapModule } from './../../configmap/configmap.module';
 import { DeploymentModule } from './../../deployment/deployment.module';
 import { EnvironmentRoutingModule } from './../environment-routing.module';
-import { TreeModule } from 'angular-tree-component';
+import { TreeModule } from 'angular2-tree-component';
 import { TreeListModule, SlideOutPanelModule } from 'ngx-widgets';
 import { TestAppModule } from './../../../../app.test.module';
 /* tslint:disable:no-unused-variable */


### PR DESCRIPTION
Downgrading angular-tree-component to 2.7.0 to avoid recent issues with the Angular 4 upgrade.

PRs for platform and planner:
https://github.com/fabric8io/fabric8-ui/pull/675
https://github.com/fabric8io/fabric8-planner/pull/1589