### PR TITLE
fixes #456 to make the environments page lazy load

### DIFF
--- a/src/app/kubernetes/ui/build/list-page/list-page.build.component.html
+++ b/src/app/kubernetes/ui/build/list-page/list-page.build.component.html
@@ -1,4 +1,6 @@
 <div class='builds list'>
   <fabric8-builds-list-toolbar></fabric8-builds-list-toolbar>
-  <fabric8-builds-list [builds]="builds | async" [loading]="loading | async"></fabric8-builds-list>
+  <div class="list-group list-view-pf list-view-pf-view">
+    <fabric8-builds-list [builds]="builds | async" [loading]="loading | async"></fabric8-builds-list>
+  </div>
 </div>

--- a/src/app/kubernetes/ui/build/list/list.build.component.html
+++ b/src/app/kubernetes/ui/build/list/list.build.component.html
@@ -1,4 +1,4 @@
-<div class='list-group list-view-pf list-view-pf-view'>
+<div class='list-group list-view-pf'>
 
   <fabric8-loading [loading]="loading">
     <div class='list-group-item build' *ngFor='let build of builds'>

--- a/src/app/kubernetes/ui/build/list/list.build.component.html
+++ b/src/app/kubernetes/ui/build/list/list.build.component.html
@@ -1,4 +1,4 @@
-<div class='list-group list-view-pf'>
+<div class='kube-resource-list'>
 
   <fabric8-loading [loading]="loading">
     <div class='list-group-item build' *ngFor='let build of builds'>

--- a/src/app/kubernetes/ui/buildconfig/list-page/list-page.buildconfig.component.html
+++ b/src/app/kubernetes/ui/buildconfig/list-page/list-page.buildconfig.component.html
@@ -1,4 +1,7 @@
 <div class='buildconfigs list'>
   <fabric8-buildconfigs-list-toolbar></fabric8-buildconfigs-list-toolbar>
-  <fabric8-buildconfigs-list [buildconfigs]="buildconfigs | async" [loading]="loading | async"></fabric8-buildconfigs-list>
+  <div class="list-group list-view-pf list-view-pf-view">
+    <fabric8-buildconfigs-list [buildconfigs]="buildconfigs | async"
+                               [loading]="loading | async"></fabric8-buildconfigs-list>
+  </div>
 </div>

--- a/src/app/kubernetes/ui/buildconfig/list/list.buildconfig.component.html
+++ b/src/app/kubernetes/ui/buildconfig/list/list.buildconfig.component.html
@@ -1,4 +1,4 @@
-<div class='list-group list-view-pf list-view-pf-view'>
+<div class='list-group list-view-pf'>
 
   <fabric8-loading [loading]="loading">
     <div class='list-group-item buildconfig' *ngFor='let buildconfig of buildconfigs'>

--- a/src/app/kubernetes/ui/buildconfig/list/list.buildconfig.component.html
+++ b/src/app/kubernetes/ui/buildconfig/list/list.buildconfig.component.html
@@ -1,4 +1,4 @@
-<div class='list-group list-view-pf'>
+<div class='kube-resource-list'>
 
   <fabric8-loading [loading]="loading">
     <div class='list-group-item buildconfig' *ngFor='let buildconfig of buildconfigs'>

--- a/src/app/kubernetes/ui/configmap/list-page/list-page.configmap.component.html
+++ b/src/app/kubernetes/ui/configmap/list-page/list-page.configmap.component.html
@@ -1,4 +1,6 @@
 <div class='configmaps list'>
   <fabric8-configmaps-list-toolbar></fabric8-configmaps-list-toolbar>
-  <fabric8-configmaps-list [configmaps]="configmaps | async" [loading]="loading | async"></fabric8-configmaps-list>
+  <div class="list-group list-view-pf list-view-pf-view">
+    <fabric8-configmaps-list [configmaps]="configmaps | async" [loading]="loading | async"></fabric8-configmaps-list>
+  </div>
 </div>

--- a/src/app/kubernetes/ui/configmap/list/list.configmap.component.html
+++ b/src/app/kubernetes/ui/configmap/list/list.configmap.component.html
@@ -1,4 +1,4 @@
-<div class='list-group list-view-pf list-view-pf-view'>
+<div class='list-group list-view-pf'>
 
   <fabric8-loading [loading]="loading">
     <div class='list-group-item configmap' *ngFor='let configmap of configmaps'>

--- a/src/app/kubernetes/ui/configmap/list/list.configmap.component.html
+++ b/src/app/kubernetes/ui/configmap/list/list.configmap.component.html
@@ -1,4 +1,4 @@
-<div class='list-group list-view-pf'>
+<div class='kube-resource-list'>
 
   <fabric8-loading [loading]="loading">
     <div class='list-group-item configmap' *ngFor='let configmap of configmaps'>

--- a/src/app/kubernetes/ui/deployment/list-page/list-page.deployment.component.html
+++ b/src/app/kubernetes/ui/deployment/list-page/list-page.deployment.component.html
@@ -1,4 +1,6 @@
 <div class='deployments list'>
   <fabric8-deployments-list-toolbar></fabric8-deployments-list-toolbar>
-  <fabric8-deployments-list [runtimeDeployments]="runtimeDeployments | async" [loading]="loading | async"></fabric8-deployments-list>
+  <div class="list-group list-view-pf list-view-pf-view">
+    <fabric8-deployments-list [runtimeDeployments]="runtimeDeployments | async" [loading]="loading | async"></fabric8-deployments-list>
+  </div>
 </div>

--- a/src/app/kubernetes/ui/deployment/list/list.deployment.component.html
+++ b/src/app/kubernetes/ui/deployment/list/list.deployment.component.html
@@ -1,4 +1,4 @@
-<div class='list-group list-view-pf'>
+<div class='kube-resource-list'>
 
   <fabric8-loading [loading]="loading">
     <div class='list-group-item deployment' *ngFor='let deployment of runtimeDeployments'>

--- a/src/app/kubernetes/ui/deployment/list/list.deployment.component.html
+++ b/src/app/kubernetes/ui/deployment/list/list.deployment.component.html
@@ -1,4 +1,4 @@
-<div class='list-group list-view-pf list-view-pf-view'>
+<div class='list-group list-view-pf'>
 
   <fabric8-loading [loading]="loading">
     <div class='list-group-item deployment' *ngFor='let deployment of runtimeDeployments'>

--- a/src/app/kubernetes/ui/environment/list/list.environment.component.html
+++ b/src/app/kubernetes/ui/environment/list/list.environment.component.html
@@ -1,86 +1,92 @@
 <fabric8-loading [loading]="loading">
-  <div id="environments" class="content container">
+  <div id="environments">
     <div class="environment" *ngFor="let e of environments">
       <div class="row">
         <div class="col-md-4">
-          <h2>{{e.environment.name}}</h2>
-        </div>
-        <div class="col-md-4">
-          <span class="openshift-console-link-panel" *ngIf="e.openshiftConsoleUrl">
+          <h2 *ngIf="!e.openshiftConsoleUrl">{{e.environment.name}}</h2>
+          <h2 *ngIf="e.openshiftConsoleUrl">
             <a [href]="e.openshiftConsoleUrl" title="View this environment in the OpenShift console">
-              See more in OpenShift console &nbsp;<span class="fa fa-external-link"></span>
+              {{e.environment.name}}
             </a>
-          </span>
+          </h2>
         </div>
       </div>
 
-      <alm-tree-list #treeList [listTemplate]="treeListTemplate" [nodes]="e.kinds" [options]="options" [showExpander]="false">
-        <ng-template #treeListTemplate let-node="node" let-index="index">
-          <div [ngSwitch]="node.parent?.data?.kind?.path?.toLowerCase()">
-            <div *ngSwitchCase="'configmaps'" class="environment-listing">
-              <alm-tree-list-item [node]="node" [template]="treeListItemTemplate">
-                <ng-template #treeListItemTemplate>
-                  <fabric8-configmaps-list [configmaps]="node.data.data | async" [loading]="node.data.loading | async"
-                                           [prefix]="'namespaces/' + e.environment.namespaceName + '/configmaps'"
-                                           [hideCheckbox]='true'></fabric8-configmaps-list>
-                </ng-template>
-              </alm-tree-list-item>
-            </div>
-            <div *ngSwitchCase="'deployments'" class="environment-listing">
-              <alm-tree-list-item [node]="node" [template]="treeListItemTemplate">
-                <ng-template #treeListItemTemplate>
-                  <fabric8-deployments-list [runtimeDeployments]="node.data.data | async" [loading]="node.data.loading | async"
-                                            [prefix]="'namespaces/' + e.environment.namespaceName + '/deployments'"
-                                            [hideCheckbox]='true'></fabric8-deployments-list>
-                </ng-template>
-              </alm-tree-list-item>
-            </div>
-            <div *ngSwitchCase="'events'" class="environment-listing">
-              <alm-tree-list-item [node]="node" [template]="treeListItemTemplate">
-                <ng-template #treeListItemTemplate>
-                  <fabric8-events-list [events]="node.data.data | async" [loading]="node.data.loading | async"
-                                       [prefix]="'namespaces/' + e.environment.namespaceName + '/events'"
-                                       [hideCheckbox]='true'></fabric8-events-list>
-                </ng-template>
-              </alm-tree-list-item>
-            </div>
-            <div *ngSwitchCase="'pods'" class="environment-listing">
-              <alm-tree-list-item [node]="node" [template]="treeListItemTemplate">
-                <ng-template #treeListItemTemplate>
-                  <fabric8-pods-list [pods]="node.data.data | async" [loading]="node.data.loading | async"
-                                     [prefix]="'namespaces/' + e.environment.namespaceName + '/pods'"
-                                     [hideCheckbox]='true'></fabric8-pods-list>
-                </ng-template>
-              </alm-tree-list-item>
-            </div>
-            <div *ngSwitchCase="'replicasets'" class="environment-listing">
-              <alm-tree-list-item [node]="node" [template]="treeListItemTemplate">
-                <ng-template #treeListItemTemplate>
-                  <fabric8-replicasets-list [runtimeReplicaSets]="node.data.data | async" [loading]="node.data.loading | async"
-                                            [prefix]="'namespaces/' + e.environment.namespaceName + '/replicasets'"
-                                            [hideCheckbox]='true'></fabric8-replicasets-list>
-                </ng-template>
-              </alm-tree-list-item>
-            </div>
-            <div *ngSwitchCase="'services'" class="environment-listing">
-              <alm-tree-list-item [node]="node" [template]="treeListItemTemplate">
-                <ng-template #treeListItemTemplate>
-                  <fabric8-services-list [services]="node.data.data | async" [loading]="node.data.loading | async"
-                                         [prefix]="'namespaces/' + e.environment.namespaceName + '/services'"
-                                         [hideCheckbox]='true'></fabric8-services-list>
-                </ng-template>
-              </alm-tree-list-item>
-            </div>
-            <div *ngSwitchDefault>
-              <alm-tree-list-item [node]="node" [template]="treeListItemTemplate">
-                <ng-template #treeListItemTemplate>
-                  <span title="{{node.data.subTitle}}">{{ node.data.title | async }}</span>
-                </ng-template>
-              </alm-tree-list-item>
-            </div>
-          </div>
-        </ng-template>
-      </alm-tree-list>
+      <div class="row">
+        <div class="col-md-12">
+          <alm-tree-list #treeList [listTemplate]="treeListTemplate" [nodes]="e.kinds" [options]="options"
+                         [showExpander]="false">
+            <ng-template #treeListTemplate let-node="node" let-index="index">
+              <div [ngSwitch]="node.parent?.data?.kind?.path?.toLowerCase()">
+                <div *ngSwitchCase="'configmaps'" class="environment-listing">
+                  <alm-tree-list-item [node]="node" [template]="treeListItemTemplate">
+                    <ng-template #treeListItemTemplate>
+                      <fabric8-configmaps-list [configmaps]="node.data.data | async"
+                                               [loading]="node.data.loading | async"
+                                               [prefix]="'namespaces/' + e.environment.namespaceName + '/configmaps'"
+                                               [hideCheckbox]='true'></fabric8-configmaps-list>
+                    </ng-template>
+                  </alm-tree-list-item>
+                </div>
+                <div *ngSwitchCase="'deployments'" class="environment-listing">
+                  <alm-tree-list-item [node]="node" [template]="treeListItemTemplate">
+                    <ng-template #treeListItemTemplate>
+                      <fabric8-deployments-list [runtimeDeployments]="node.data.data | async"
+                                                [loading]="node.data.loading | async"
+                                                [prefix]="'namespaces/' + e.environment.namespaceName + '/deployments'"
+                                                [hideCheckbox]='true'></fabric8-deployments-list>
+                    </ng-template>
+                  </alm-tree-list-item>
+                </div>
+                <div *ngSwitchCase="'events'" class="environment-listing">
+                  <alm-tree-list-item [node]="node" [template]="treeListItemTemplate">
+                    <ng-template #treeListItemTemplate>
+                      <fabric8-events-list [events]="node.data.data | async" [loading]="node.data.loading | async"
+                                           [prefix]="'namespaces/' + e.environment.namespaceName + '/events'"
+                                           [hideCheckbox]='true'></fabric8-events-list>
+                    </ng-template>
+                  </alm-tree-list-item>
+                </div>
+                <div *ngSwitchCase="'pods'" class="environment-listing">
+                  <alm-tree-list-item [node]="node" [template]="treeListItemTemplate">
+                    <ng-template #treeListItemTemplate>
+                      <fabric8-pods-list [pods]="node.data.data | async" [loading]="node.data.loading | async"
+                                         [prefix]="'namespaces/' + e.environment.namespaceName + '/pods'"
+                                         [hideCheckbox]='true'></fabric8-pods-list>
+                    </ng-template>
+                  </alm-tree-list-item>
+                </div>
+                <div *ngSwitchCase="'replicasets'" class="environment-listing">
+                  <alm-tree-list-item [node]="node" [template]="treeListItemTemplate">
+                    <ng-template #treeListItemTemplate>
+                      <fabric8-replicasets-list [runtimeReplicaSets]="node.data.data | async"
+                                                [loading]="node.data.loading | async"
+                                                [prefix]="'namespaces/' + e.environment.namespaceName + '/replicasets'"
+                                                [hideCheckbox]='true'></fabric8-replicasets-list>
+                    </ng-template>
+                  </alm-tree-list-item>
+                </div>
+                <div *ngSwitchCase="'services'" class="environment-listing">
+                  <alm-tree-list-item [node]="node" [template]="treeListItemTemplate">
+                    <ng-template #treeListItemTemplate>
+                      <fabric8-services-list [services]="node.data.data | async" [loading]="node.data.loading | async"
+                                             [prefix]="'namespaces/' + e.environment.namespaceName + '/services'"
+                                             [hideCheckbox]='true'></fabric8-services-list>
+                    </ng-template>
+                  </alm-tree-list-item>
+                </div>
+                <div *ngSwitchDefault>
+                  <alm-tree-list-item [node]="node" [template]="treeListItemTemplate">
+                    <ng-template #treeListItemTemplate>
+                      <span title="{{node.data.subTitle}}">{{ node.data.title | async }}</span>
+                    </ng-template>
+                  </alm-tree-list-item>
+                </div>
+              </div>
+            </ng-template>
+          </alm-tree-list>
+        </div>
+      </div>
     </div>
   </div>
 </fabric8-loading>

--- a/src/app/kubernetes/ui/event/list-page/list-page.event.component.html
+++ b/src/app/kubernetes/ui/event/list-page/list-page.event.component.html
@@ -1,4 +1,6 @@
 <div class='events list'>
   <fabric8-events-list-toolbar></fabric8-events-list-toolbar>
-  <fabric8-events-list [events]="events | async" [loading]="loading | async"></fabric8-events-list>
+  <div class="list-group list-view-pf list-view-pf-view">
+    <fabric8-events-list [events]="events | async" [loading]="loading | async"></fabric8-events-list>
+  </div>
 </div>

--- a/src/app/kubernetes/ui/event/list/list.event.component.html
+++ b/src/app/kubernetes/ui/event/list/list.event.component.html
@@ -1,4 +1,4 @@
-<div class='list-group list-view-pf'>
+<div class='kube-resource-list'>
 
   <fabric8-loading [loading]="loading">
     <div class='list-group-item event' *ngFor='let event of events'>

--- a/src/app/kubernetes/ui/event/list/list.event.component.html
+++ b/src/app/kubernetes/ui/event/list/list.event.component.html
@@ -1,4 +1,4 @@
-<div class='list-group list-view-pf list-view-pf-view'>
+<div class='list-group list-view-pf'>
 
   <fabric8-loading [loading]="loading">
     <div class='list-group-item event' *ngFor='let event of events'>

--- a/src/app/kubernetes/ui/namespace/list-page/list-page.namespace.component.html
+++ b/src/app/kubernetes/ui/namespace/list-page/list-page.namespace.component.html
@@ -1,6 +1,8 @@
 <div class="container-fluid container-cards-pf">
   <div class='namespaces list'>
     <fabric8-namespaces-list-toolbar></fabric8-namespaces-list-toolbar>
-    <fabric8-namespaces-list [namespaces]="namespaces | async" [loading]="loading | async"></fabric8-namespaces-list>
+    <div class="list-group list-view-pf list-view-pf-view">
+      <fabric8-namespaces-list [namespaces]="namespaces | async" [loading]="loading | async"></fabric8-namespaces-list>
+    </div>
   </div>
 </div>

--- a/src/app/kubernetes/ui/namespace/list/list.namespace.component.html
+++ b/src/app/kubernetes/ui/namespace/list/list.namespace.component.html
@@ -1,4 +1,4 @@
-<div class='list-group list-view-pf list-view-pf-view'>
+<div class='list-group list-view-pf'>
 
   <fabric8-loading [loading]="loading">
     <div class='list-group-item namespace' *ngFor='let namespace of namespaces'>

--- a/src/app/kubernetes/ui/namespace/list/list.namespace.component.html
+++ b/src/app/kubernetes/ui/namespace/list/list.namespace.component.html
@@ -1,4 +1,4 @@
-<div class='list-group list-view-pf'>
+<div class='kube-resource-list'>
 
   <fabric8-loading [loading]="loading">
     <div class='list-group-item namespace' *ngFor='let namespace of namespaces'>

--- a/src/app/kubernetes/ui/pipeline/full-history/full-history.pipeline.component.html
+++ b/src/app/kubernetes/ui/pipeline/full-history/full-history.pipeline.component.html
@@ -1,4 +1,4 @@
-<div class='list-group list-view-pf'>
+<div class='kube-resource-list'>
 
   <fabric8-loading [loading]="loading">
     <div class="pipelines-page">

--- a/src/app/kubernetes/ui/pipeline/full-history/full-history.pipeline.component.html
+++ b/src/app/kubernetes/ui/pipeline/full-history/full-history.pipeline.component.html
@@ -1,4 +1,4 @@
-<div class='list-group list-view-pf list-view-pf-view'>
+<div class='list-group list-view-pf'>
 
   <fabric8-loading [loading]="loading">
     <div class="pipelines-page">

--- a/src/app/kubernetes/ui/pipeline/history/history.pipeline.component.html
+++ b/src/app/kubernetes/ui/pipeline/history/history.pipeline.component.html
@@ -1,4 +1,4 @@
-<div class='list-group list-view-pf list-view-pf-view'>
+<div class='list-group list-view-pf'>
 
   <fabric8-loading [loading]="loading">
     <div class="pipelines-page" *ngIf="pipeline">

--- a/src/app/kubernetes/ui/pipeline/history/history.pipeline.component.html
+++ b/src/app/kubernetes/ui/pipeline/history/history.pipeline.component.html
@@ -1,4 +1,4 @@
-<div class='list-group list-view-pf'>
+<div class='kube-resource-list'>
 
   <fabric8-loading [loading]="loading">
     <div class="pipelines-page" *ngIf="pipeline">

--- a/src/app/kubernetes/ui/pipeline/list-page/list-page.pipeline.component.html
+++ b/src/app/kubernetes/ui/pipeline/list-page/list-page.pipeline.component.html
@@ -1,4 +1,6 @@
 <div class='pipelines list'>
   <fabric8-pipelines-list-toolbar></fabric8-pipelines-list-toolbar>
-  <fabric8-pipelines-list [pipelines]="pipelines | async" [loading]="loading | async"></fabric8-pipelines-list>
+  <div class="list-group list-view-pf list-view-pf-view">
+    <fabric8-pipelines-list [pipelines]="pipelines | async" [loading]="loading | async"></fabric8-pipelines-list>
+  </div>
 </div>

--- a/src/app/kubernetes/ui/pipeline/list/list.pipeline.component.html
+++ b/src/app/kubernetes/ui/pipeline/list/list.pipeline.component.html
@@ -1,4 +1,4 @@
-<div class='list-group list-view-pf'>
+<div class='kube-resource-list'>
 
   <fabric8-loading [loading]="loading">
     <div class="pipelines-page">

--- a/src/app/kubernetes/ui/pipeline/list/list.pipeline.component.html
+++ b/src/app/kubernetes/ui/pipeline/list/list.pipeline.component.html
@@ -1,4 +1,4 @@
-<div class='list-group list-view-pf list-view-pf-view'>
+<div class='list-group list-view-pf'>
 
   <fabric8-loading [loading]="loading">
     <div class="pipelines-page">

--- a/src/app/kubernetes/ui/pod/list-page/list-page.pod.component.html
+++ b/src/app/kubernetes/ui/pod/list-page/list-page.pod.component.html
@@ -1,4 +1,7 @@
 <div class='pods list'>
   <fabric8-pods-list-toolbar></fabric8-pods-list-toolbar>
-  <fabric8-pods-list [pods]="pods | async" [loading]="loading | async"></fabric8-pods-list>
+
+  <div class="list-group list-view-pf list-view-pf-view">
+    <fabric8-pods-list [pods]="pods | async" [loading]="loading | async"></fabric8-pods-list>
+  </div>
 </div>

--- a/src/app/kubernetes/ui/pod/list/list.pod.component.html
+++ b/src/app/kubernetes/ui/pod/list/list.pod.component.html
@@ -1,4 +1,4 @@
-<div class='list-group list-view-pf list-view-pf-view'>
+<div class='list-group list-view-pf'>
 
   <fabric8-loading [loading]="loading">
     <div class='list-group-item pod' *ngFor='let pod of pods'>

--- a/src/app/kubernetes/ui/pod/list/list.pod.component.html
+++ b/src/app/kubernetes/ui/pod/list/list.pod.component.html
@@ -1,4 +1,4 @@
-<div class='list-group list-view-pf'>
+<div class='kube-resource-list'>
 
   <fabric8-loading [loading]="loading">
     <div class='list-group-item pod' *ngFor='let pod of pods'>

--- a/src/app/kubernetes/ui/replicaset/list-page/list-page.replicaset.component.html
+++ b/src/app/kubernetes/ui/replicaset/list-page/list-page.replicaset.component.html
@@ -1,4 +1,7 @@
 <div class='replicasets list'>
   <fabric8-replicasets-list-toolbar></fabric8-replicasets-list-toolbar>
-  <fabric8-replicasets-list [runtimeReplicaSets]="runtimeReplicaSets | async" [loading]="loading | async"></fabric8-replicasets-list>
+  <div class="list-group list-view-pf list-view-pf-view">
+    <fabric8-replicasets-list [runtimeReplicaSets]="runtimeReplicaSets | async"
+                              [loading]="loading | async"></fabric8-replicasets-list>
+  </div>
 </div>

--- a/src/app/kubernetes/ui/replicaset/list/list.replicaset.component.html
+++ b/src/app/kubernetes/ui/replicaset/list/list.replicaset.component.html
@@ -1,4 +1,4 @@
-<div class='list-group list-view-pf'>
+<div class='kube-resource-list'>
 
   <fabric8-loading [loading]="loading">
     <div class='list-group-item replicaset' *ngFor='let replicaset of runtimeReplicaSets'>

--- a/src/app/kubernetes/ui/replicaset/list/list.replicaset.component.html
+++ b/src/app/kubernetes/ui/replicaset/list/list.replicaset.component.html
@@ -1,4 +1,4 @@
-<div class='list-group list-view-pf list-view-pf-view'>
+<div class='list-group list-view-pf'>
 
   <fabric8-loading [loading]="loading">
     <div class='list-group-item replicaset' *ngFor='let replicaset of runtimeReplicaSets'>

--- a/src/app/kubernetes/ui/service/list-page/list-page.service.component.html
+++ b/src/app/kubernetes/ui/service/list-page/list-page.service.component.html
@@ -1,4 +1,6 @@
 <div class='services list'>
   <fabric8-services-list-toolbar></fabric8-services-list-toolbar>
-  <fabric8-services-list [services]="services | async" [loading]="loading | async"></fabric8-services-list>
+  <div class="list-group list-view-pf list-view-pf-view">
+    <fabric8-services-list [services]="services | async" [loading]="loading | async"></fabric8-services-list>
+  </div>
 </div>

--- a/src/app/kubernetes/ui/service/list/list.service.component.html
+++ b/src/app/kubernetes/ui/service/list/list.service.component.html
@@ -1,4 +1,4 @@
-<div class='list-group list-view-pf'>
+<div class='kube-resource-list'>
 
   <fabric8-loading [loading]="loading">
     <div class='list-group-item service' *ngFor='let service of services'>

--- a/src/app/kubernetes/ui/service/list/list.service.component.html
+++ b/src/app/kubernetes/ui/service/list/list.service.component.html
@@ -1,4 +1,4 @@
-<div class='list-group list-view-pf list-view-pf-view'>
+<div class='list-group list-view-pf'>
 
   <fabric8-loading [loading]="loading">
     <div class='list-group-item service' *ngFor='let service of services'>

--- a/src/app/kubernetes/ui/space/list-page/list-page.space.component.html
+++ b/src/app/kubernetes/ui/space/list-page/list-page.space.component.html
@@ -1,6 +1,8 @@
 <div class="container-fluid">
   <div class='spaces list'>
     <fabric8-spaces-list-toolbar></fabric8-spaces-list-toolbar>
-    <fabric8-spaces-list [spaces]="spaces | async" [loading]="loading | async"></fabric8-spaces-list>
+    <div class="list-group list-view-pf list-view-pf-view">
+      <fabric8-spaces-list [spaces]="spaces | async" [loading]="loading | async"></fabric8-spaces-list>
+    </div>
   </div>
 </div>

--- a/src/app/kubernetes/ui/space/list/list.space.component.html
+++ b/src/app/kubernetes/ui/space/list/list.space.component.html
@@ -1,4 +1,4 @@
-<div class='list-group list-view-pf'>
+<div class='kube-resource-list'>
 
   <fabric8-loading [loading]="loading">
     <div class='list-group-item space' *ngFor='let space of spaces'>

--- a/src/app/kubernetes/ui/space/list/list.space.component.html
+++ b/src/app/kubernetes/ui/space/list/list.space.component.html
@@ -1,4 +1,4 @@
-<div class='list-group list-view-pf list-view-pf-view'>
+<div class='list-group list-view-pf'>
 
   <fabric8-loading [loading]="loading">
     <div class='list-group-item space' *ngFor='let space of spaces'>


### PR DESCRIPTION
lets reduce the mandatory header on the list views of resources which can help when embedding the resource lists inside other widgets (e.g. tree widget)