### PR TITLE
fix(runtime env vars): added runtime API URLs

### DIFF
--- a/src/app/kubernetes/store/oauth-config-store.ts
+++ b/src/app/kubernetes/store/oauth-config-store.ts
@@ -15,6 +15,10 @@ export class OAuthConfig {
   public scope: string;
   public loaded: boolean;
   public openshiftConsoleUrl: string;
+  public witApiUrl: string;
+  public ssoApiUrl: string;
+  public forgeApiUrl: string;
+  public recommenderApiUrl: string;
 
   constructor(data: any) {
     var config = data || {};
@@ -30,7 +34,11 @@ export class OAuthConfig {
     this.issuer = oauth.oauth_issuer || "";
     this.scope = oauth.oauth_scope || "user:full";
     this.logoutUri = oauth.logout_uri || "";
-    this.openshiftConsoleUrl = config.openshift_console_url;
+    this.openshiftConsoleUrl = config.openshift_console_url || "";
+    this.witApiUrl = config.wit_api_url || "";
+    this.ssoApiUrl = config.sso_api_url || "";
+    this.forgeApiUrl = config.forge_api_url || "";
+    this.recommenderApiUrl = config.recommender_api_url || "";
 
     if (!this.issuer && this.authorizeUri) {
       // lets default the issuer from the authorize Uri

--- a/src/config/oauth.json
+++ b/src/config/oauth.json
@@ -4,6 +4,10 @@
   "api_server_base_path": "{{ .Env.K8S_API_SERVER_BASE_PATH }}",
   "ws_api_server": "{{ .Env.WS_K8S_API_SERVER }}",
   "openshift_console_url": "{{ .Env.OPENSHIFT_CONSOLE_URL }}",
+  "forge_api_url": "{{ .Env.FABRIC8_FORGE_API_URL }}",
+  "wit_api_url": "{{ .Env.FABRIC8_WIT_API_URL }}",
+  "sso_api_url": "{{ .Env.FABRIC8_SSO_API_URL }}",
+  "recommender_api_url": "{{ .Env.FABRIC8_RECOMMENDER_API_URL }}",
   "oauth": {
     "oauth_authorize_uri": "{{ .Env.OAUTH_AUTHORIZE_URI }}",
     "oauth_client_id": "{{ .Env.OAUTH_CLIENT_ID }}",


### PR DESCRIPTION
lets add runtime environment variables for the API URLs for when running on premise or upstream
see https://github.com/fabric8io/fabric8-ui/issues/1316