### PR TITLE
fix(config): fix errors on missing env vars

### DIFF
--- a/src/app/kubernetes/store/oauth-config-store.ts
+++ b/src/app/kubernetes/store/oauth-config-store.ts
@@ -115,6 +115,12 @@ export class OAuthConfigStore {
       .subscribe(
         (res) => {
           let data = res.json();
+          for (let key in data) {
+            let value = data[key];
+            if (value === "undefined") {
+              data[key] = "";
+            }
+          }
           _latestOAuthConfig = new OAuthConfig(data);
           _currentOAuthConfig.next(_latestOAuthConfig);
           _loadingOAuthConfig.next(false);


### PR DESCRIPTION
if we don't configure environment variables for the new WS based values
lets not break the locally running console