### PR TITLE
fix(status): add version info back to status widget

### DIFF
--- a/src/app/kubernetes/ui/status/status-info.component.html
+++ b/src/app/kubernetes/ui/status/status-info.component.html
@@ -1,5 +1,5 @@
 <span *ngIf="info">
   <span [class]="info.iconCss"></span>&nbsp;
   <ng-content></ng-content>
-  <!--<span *ngIf="info.version" title="release version of this service">: {{info.version}}</span>-->
+  <span *ngIf="info.version" title="release version of this service">: {{info.version}}</span>
 </span>


### PR DESCRIPTION
add the version information back into the status widget, until it can be moved to the About modal