### PR TITLE
Use latest dropdown from ngx-bootstrap

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "ng2-modal": "0.0.25",
     "ngx-base": "1.2.9",
     "ng2-bootstrap": "1.3.3",
+    "ngx-bootstrap": "1.7.1",
     "ngx-fabric8-wit": "6.18.11",
     "ngx-login-client": "0.6.32",
     "ngx-widgets": "0.15.2",

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -20,7 +20,7 @@ import {HeaderComponent} from "./header/header.component";
 import {DummyService} from "./dummy/dummy.service";
 import {ContextService} from "./shared/context.service";
 import {LocalStorageModule} from 'angular-2-local-storage';
-import {DropdownConfig, DropdownModule} from "ng2-bootstrap";
+import {BsDropdownConfig, BsDropdownModule} from 'ngx-bootstrap/dropdown';
 import { OAuthService } from 'angular2-oauth2/oauth-service';
 import {OnLogin} from "./shared/onlogin.service";
 
@@ -47,11 +47,11 @@ export function restangularProviderConfigurer(restangularProvider: any, config: 
 @NgModule({
   imports: [
     BrowserModule,
+    BsDropdownModule.forRoot(),
     FormsModule,
     HttpModule,
     RestangularModule.forRoot([ConfigService], restangularProviderConfigurer),
     NgbModule.forRoot(),
-    DropdownModule,
     Fabric8CommonModule,
     KubernetesStoreModule,
     KubernetesUIModule,
@@ -67,9 +67,9 @@ export function restangularProviderConfigurer(restangularProvider: any, config: 
     HeaderComponent,
   ],
   providers: [
+    BsDropdownConfig,
     ConfigService,
     Contexts,
-    DropdownConfig,
     {
       provide: APP_INITIALIZER,
       useFactory: configServiceInitializer,

--- a/src/app/common/common.module.ts
+++ b/src/app/common/common.module.ts
@@ -6,7 +6,7 @@ import {TruncateWordsPipe} from "./truncate-words.pipe";
 import {LoadingComponent} from "./loading/loading.component";
 import {EntriesPipe} from "./entries.pipe";
 import {ResourceHeaderComponent} from "../kubernetes/components/resource-header/resource.header.component";
-import {DropdownConfig, DropdownModule} from "ng2-bootstrap";
+import {BsDropdownConfig, BsDropdownModule} from 'ngx-bootstrap/dropdown';
 import {ParentLinkFactory} from "./parent-link-factory";
 import {OAuthService} from "angular2-oauth2/oauth-service";
 import {OnLogin} from "../shared/onlogin.service";
@@ -14,9 +14,9 @@ import {SafeUrlPipe} from "./safeurl.pipe";
 
 @NgModule({
   imports: [
+    BsDropdownModule.forRoot(),
     CommonModule,
-    RouterModule,
-    DropdownModule,
+    RouterModule
   ],
   declarations: [
     EntriesPipe,
@@ -35,7 +35,7 @@ import {SafeUrlPipe} from "./safeurl.pipe";
     SafeUrlPipe,
   ],
   providers: [
-    DropdownConfig,
+    BsDropdownConfig,
     ParentLinkFactory,
     OAuthService,
     OnLogin,

--- a/src/app/header/header.component.html
+++ b/src/app/header/header.component.html
@@ -4,8 +4,8 @@
       <li *ngIf="!loggedIn">
         <a (click)='login();'>Sign In</a>
       </li>
-      <li *ngIf="loggedIn" class="pull-right" dropdown>
-        <a class="pull-right" dropdownToggle>
+      <li *ngIf="loggedIn" class="pull-right dropdown" dropdown>
+        <a class="pull-right dropdown-toggle" dropdownToggle>
           <div *ngIf="loggedInUser" id="header_dropdownToggle_header">
             <span class="nav-item-icon">
               <span *ngIf="!imgLoaded" class="nav-icon pficon-user"></span>
@@ -15,7 +15,7 @@
             <span class="nav-icon caret"></span>
           </div>
         </a>
-        <ul class="view-width-100" role="menu" dropdownMenu>
+        <ul class="view-width-100 dropdown-menu" role="menu" *dropdownMenu>
           <li>
             <a [routerLink]="[urlFeatureToggle + '/pmuir']">
               <span class="nav-item-text">Profile</span>
@@ -44,8 +44,8 @@
   <div class="collapse navbar-collapse navbar-collapse-1">
     <ul class="nav navbar-nav navbar-primary persistent-secondary navbar-left">
       <!-- This part of the menu is dynamic based on context -->
-      <li class="context" dropdown>
-        <a dropdownToggle>
+      <li class="context dropdown" dropdown>
+        <a class="dropdown-toggle" dropdownToggle>
           <div *ngIf="loggedInUser" id="header_dropdownToggle">
             <span *ngIf="dummy.currentContext.type" class="nav-item-icon">
               <span class="nav-icon {{dummy.currentContext.type.icon}}"></span>
@@ -56,7 +56,7 @@
             </span>
           </div>
         </a>
-        <ul role="menu" dropdownMenu>
+        <ul class="dropdown-menu" role="menu" *dropdownMenu>
           <li>
             <a [routerLink]="['/run/spaces']" title="Browse all spaces">browse spaces</a>
           </li>
@@ -108,8 +108,8 @@
       <li>
         <a *ngIf="!loggedIn" (click)='login();'>Sign In</a>
       </li>
-      <li *ngIf="loggedIn" class="pull-right" dropdown>
-        <a dropdownToggle>
+      <li *ngIf="loggedIn" class="pull-right dropdown" dropdown>
+        <a class="dropdown-toggle" dropdownToggle>
           <div *ngIf="loggedInUser" id="header_dropdownToggle2">
             <span class="nav-item-icon">
               <span *ngIf="!imgLoaded" class="nav-icon pficon-user"></span>
@@ -121,7 +121,7 @@
             </span>
           </div>
         </a>
-        <ul role="menu" dropdownMenu>
+        <ul class="dropdown-menu" role="menu" *dropdownMenu>
           <li>
             <a [routerLink]="[urlFeatureToggle + '/pmuir']"><span class="nav-item-text">Profile</span> </a>
           </li>

--- a/src/app/kubernetes/components/resource-header/resource.header.component.html
+++ b/src/app/kubernetes/components/resource-header/resource.header.component.html
@@ -1,9 +1,9 @@
-<div class='context' dropdown>
-  <button type='button' class='btn btn-default' aria-haspopup='true' aria-expanded='false' dropdownToggle>
+<div class='context dropdown' dropdown>
+  <button type='button' class='btn btn-default dropdown-toggle' aria-haspopup='true' aria-expanded='false' dropdownToggle>
     {{current?.name}}
     <span class='caret'></span>
   </button>
-  <ul role="menu" dropdownMenu>
+  <ul class="dropdown-menu" role="menu" *dropdownMenu>
     <li *ngFor="let m of menus">
       <a [routerLink]="[m.fullPath || m.path]" *ngIf="m.path !== null && m != current?.path">
         <span class="{{m.icon}}"></span> {{m.name}}

--- a/src/app/kubernetes/ui/app/app.module.ts
+++ b/src/app/kubernetes/ui/app/app.module.ts
@@ -7,12 +7,11 @@ import {DeploymentModule} from "./../deployment/deployment.module";
 import {ConfigMapStore} from "./../../store/configmap.store";
 import {NamespaceStore} from "./../../store/namespace.store";
 import {NgModule} from "@angular/core";
-import {DropdownConfig, DropdownModule} from "ng2-bootstrap";
+import {BsDropdownConfig, BsDropdownModule} from 'ngx-bootstrap/dropdown';
 import {CommonModule} from "@angular/common";
 import {FormsModule} from "@angular/forms";
 import {RouterModule} from "@angular/router";
 import {ModalModule} from "ng2-modal";
-import {ToolbarModule} from "ngx-widgets";
 import {Fabric8CommonModule} from "../../../common/common.module";
 import {MomentModule} from "angular2-moment";
 import {KubernetesComponentsModule} from "../../components/components.module";
@@ -26,15 +25,14 @@ import {AppRoutingModule} from "./app-routing.module";
 
 @NgModule({
   imports: [
+    BsDropdownModule.forRoot(),
     CommonModule,
-    DropdownModule,
     FormsModule,
     ModalModule,
     MomentModule,
     RouterModule,
     Fabric8CommonModule,
     KubernetesComponentsModule,
-    ToolbarModule,
     // Our Routing MUST go before the other Kuberenetes UI modules, so our routes take precedence
     AppRoutingModule,
     DeploymentModule,
@@ -50,7 +48,7 @@ import {AppRoutingModule} from "./app-routing.module";
     AppListComponent,
   ],
   providers: [
-    DropdownConfig,
+    BsDropdownConfig,
     NamespaceStore,
     ConfigMapService,
     ConfigMapStore,

--- a/src/app/kubernetes/ui/app/list-toolbar/list-toolbar.app.component.html
+++ b/src/app/kubernetes/ui/app/list-toolbar/list-toolbar.app.component.html
@@ -7,11 +7,11 @@
       <div class='form-group toolbar-pf-filter search'>
         <label class='sr-only'>Name</label>
         <div class='input-group'>
-          <div class='input-group-btn' dropdown>
-            <button type='button' class='btn btn-default' aria-haspopup='true' aria-expanded='false' dropdownToggle>Name&nbsp;
+          <div class='input-group-btn dropdown' dropdown>
+            <button type='button' class='btn btn-default dropdown-toggle' aria-haspopup='true' aria-expanded='false' dropdownToggle>Name&nbsp;
                 <span class='caret'></span>
               </button>
-            <ul role="menu" dropdownMenu>
+            <ul class="dropdown-menu" role="menu" *dropdownMenu>
               <li>
                 <a href='#'>Name</a>
               </li>
@@ -27,11 +27,11 @@
       <!-- Toolbar: Sort -->
 
       <div class='form-group sort'>
-        <div class='dropdown btn-group' dropdown>
-          <button type='button' class='btn btn-default' aria-haspopup='true' aria-expanded='false' dropdownToggle>Name&nbsp;
+        <div class='dropdown btn-group dropdown' dropdown>
+          <button type='button' class='btn btn-default dropdown-toggle' aria-haspopup='true' aria-expanded='false' dropdownToggle>Name&nbsp;
               <span class='caret'></span>
             </button>
-          <ul role="menu" dropdownMenu>
+          <ul class="dropdown-menu" role="menu" *dropdownMenu>
             <li>
               <a href='#'>Name</a>
             </li>

--- a/src/app/kubernetes/ui/app/list/list.app.component.html
+++ b/src/app/kubernetes/ui/app/list/list.app.component.html
@@ -55,12 +55,12 @@
                   </span>
                 </span>
 
-                <span class='pull-right dropdown-kebab-pf' dropdown>
-                  <button class='btn btn-link kebab' type='button'
+                <span class='pull-right dropdown-kebab-pf dropdown' dropdown>
+                  <button class='btn btn-link kebab dropdown-toggle' type='button'
                           aria-haspopup='true' aria-expanded='true' dropdownToggle>
                     <span class='fa fa-ellipsis-v'></span>
                   </button>
-                  <ul class='dropdown-menu-right' aria-labelledby='dropdownKebabRight9' role="menu" dropdownMenu>
+                  <ul class='dropdown-menu-right dropdown-menu' aria-labelledby='dropdownKebabRight9' role="menu" *dropdownMenu>
                     <li>
                       <a (click)="openScaleDialog(scaleDeploymentModal, envInfo.deployment.deployment)"
                          *ngIf="envInfo.deployment.deployment"

--- a/src/app/kubernetes/ui/build/build.module.ts
+++ b/src/app/kubernetes/ui/build/build.module.ts
@@ -1,6 +1,6 @@
 import {NgModule} from "@angular/core";
 import {CommonModule} from "@angular/common";
-import {DropdownConfig, DropdownModule} from "ng2-bootstrap";
+import {BsDropdownConfig, BsDropdownModule} from 'ngx-bootstrap/dropdown';
 import {FormsModule} from "@angular/forms";
 import {RouterModule, Routes} from "@angular/router";
 import {ModalModule} from "ng2-modal";
@@ -28,8 +28,8 @@ const routes: Routes = [
 
 @NgModule({
   imports: [
+    BsDropdownModule.forRoot(),
     CommonModule,
-    DropdownModule,
     FormsModule,
     ModalModule,
     MomentModule,
@@ -59,7 +59,7 @@ const routes: Routes = [
     ModalModule,
   ],
   providers: [
-    DropdownConfig
+    BsDropdownConfig
   ]
 })
 export class BuildModule {

--- a/src/app/kubernetes/ui/build/list-toolbar/list-toolbar.build.component.html
+++ b/src/app/kubernetes/ui/build/list-toolbar/list-toolbar.build.component.html
@@ -12,11 +12,11 @@
       <div class='form-group toolbar-pf-filter search'>
         <label class='sr-only'>Name</label>
         <div class='input-group'>
-          <div class='input-group-btn' dropdown>
-            <button type='button' class='btn btn-default' aria-haspopup='true' aria-expanded='false' dropdownToggle>Name&nbsp;
+          <div class='input-group-btn dropdown' dropdown>
+            <button type='button' class='btn btn-default dropdown-toggle' aria-haspopup='true' aria-expanded='false' dropdownToggle>Name&nbsp;
               <span class='caret'></span>
             </button>
-            <ul role="menu" dropdownMenu>
+            <ul class="dropdown-menu" role="menu" *dropdownMenu>
               <li>
                 <a href='#'>Name</a>
               </li>
@@ -32,11 +32,11 @@
       <!-- Toolbar: Sort -->
 
       <div class='form-group sort'>
-        <div class='btn-group' dropdown>
-          <button type='button' class='btn btn-default' aria-haspopup='true' aria-expanded='false' dropdownToggle>Name&nbsp;
+        <div class='btn-group dropdown' dropdown>
+          <button type='button' class='btn btn-default dropdown-toggle' aria-haspopup='true' aria-expanded='false' dropdownToggle>Name&nbsp;
             <span class='caret'></span>
           </button>
-          <ul role="menu" dropdownMenu>
+          <ul class="dropdown-menu" role="menu" *dropdownMenu>
             <li>
               <a href='#'>Name</a>
             </li>

--- a/src/app/kubernetes/ui/build/list/list.build.component.html
+++ b/src/app/kubernetes/ui/build/list/list.build.component.html
@@ -6,11 +6,11 @@
         <input type='checkbox'>
       </div>
       <div class='list-view-pf-actions'>
-        <div class='pull-right dropdown-kebab-pf' dropdown>
-          <button class='btn btn-link' type='button' id='dropdownKebabRight9' aria-haspopup='true' aria-expanded='true' dropdownToggle>
+        <div class='pull-right dropdown-kebab-pf dropdown' dropdown>
+          <button class='btn btn-link dropdown-toggle' type='button' id='dropdownKebabRight9' aria-haspopup='true' aria-expanded='true' dropdownToggle>
               <span class='fa fa-ellipsis-v'></span>
             </button>
-          <ul class='dropdown-menu-right' aria-labelledby='dropdownKebabRight9' role="menu" dropdownMenu>
+          <ul class='dropdown-menu-right dropdown-menu' aria-labelledby='dropdownKebabRight9' role="menu" *dropdownMenu>
             <li *ngIf="build.openShiftConsoleUrl">
               <a [href]="build.openShiftConsoleUrl" target="openshift"
                  title="View this Build in the OpenShift Console">OpenShift Console</a>

--- a/src/app/kubernetes/ui/buildconfig/buildconfig.module.ts
+++ b/src/app/kubernetes/ui/buildconfig/buildconfig.module.ts
@@ -1,6 +1,6 @@
 import {NgModule} from "@angular/core";
 import {CommonModule} from "@angular/common";
-import {DropdownConfig, DropdownModule} from "ng2-bootstrap";
+import {BsDropdownConfig, BsDropdownModule} from 'ngx-bootstrap/dropdown';
 import {FormsModule} from "@angular/forms";
 import {RouterModule, Routes} from "@angular/router";
 import {ModalModule} from "ng2-modal";
@@ -29,8 +29,8 @@ const routes: Routes = [
 
 @NgModule({
   imports: [
+    BsDropdownModule.forRoot(),
     CommonModule,
-    DropdownModule,
     FormsModule,
     ModalModule,
     MomentModule,
@@ -56,7 +56,7 @@ const routes: Routes = [
     BuildConfigEditPage,
   ],
   providers: [
-    DropdownConfig
+    BsDropdownConfig
   ]
 })
 export class BuildConfigModule {

--- a/src/app/kubernetes/ui/buildconfig/list-toolbar/list-toolbar.buildconfig.component.html
+++ b/src/app/kubernetes/ui/buildconfig/list-toolbar/list-toolbar.buildconfig.component.html
@@ -12,11 +12,11 @@
       <div class='form-group toolbar-pf-filter search'>
         <label class='sr-only'>Name</label>
         <div class='input-group'>
-          <div class='input-group-btn' dropdown>
-            <button type='button' class='btn btn-default' aria-haspopup='true' aria-expanded='false' dropdownToggle>Name&nbsp;
+          <div class='input-group-btn dropdown' dropdown>
+            <button type='button' class='btn btn-default dropdown-toggle' aria-haspopup='true' aria-expanded='false' dropdownToggle>Name&nbsp;
               <span class='caret'></span>
             </button>
-            <ul role="menu" dropdownMenu>
+            <ul class="dropdown-menu" role="menu" *dropdownMenu>
               <li>
                 <a href='#'>Name</a>
               </li>
@@ -32,11 +32,11 @@
       <!-- Toolbar: Sort -->
 
       <div class='form-group sort'>
-        <div class='btn-group' dropdown>
-          <button type='button' class='btn btn-default' aria-haspopup='true' aria-expanded='false' dropdownToggle>Name&nbsp;
+        <div class='btn-group dropdown' dropdown>
+          <button type='button' class='btn btn-default dropdown-toggle' aria-haspopup='true' aria-expanded='false' dropdownToggle>Name&nbsp;
             <span class='caret'></span>
           </button>
-          <ul role="menu" dropdownMenu>
+          <ul class="dropdown-menu" role="menu" *dropdownMenu>
             <li>
               <a href='#'>Name</a>
             </li>

--- a/src/app/kubernetes/ui/buildconfig/list/list.buildconfig.component.html
+++ b/src/app/kubernetes/ui/buildconfig/list/list.buildconfig.component.html
@@ -6,11 +6,11 @@
         <input type='checkbox'>
       </div>
       <div class='list-view-pf-actions'>
-        <div class='pull-right dropdown-kebab-pf' dropdown>
-          <button class='btn btn-link' type='button' id='dropdownKebabRight9' aria-haspopup='true' aria-expanded='true' dropdownToggle>
+        <div class='pull-right dropdown-kebab-pf dropdown' dropdown>
+          <button class='btn btn-link dropdown-toggle' type='button' id='dropdownKebabRight9' aria-haspopup='true' aria-expanded='true' dropdownToggle>
               <span class='fa fa-ellipsis-v'></span>
             </button>
-          <ul class='dropdown-menu-right' aria-labelledby='dropdownKebabRight9' role="menu" dropdownMenu>
+          <ul class='dropdown-menu-right dropdown-menu' aria-labelledby='dropdownKebabRight9' role="menu" *dropdownMenu>
             <li>
               <a (click)="startBuild(buildconfig)" title="Start this Build">Start Build</a>
             </li>

--- a/src/app/kubernetes/ui/configmap/configmap.module.ts
+++ b/src/app/kubernetes/ui/configmap/configmap.module.ts
@@ -1,6 +1,6 @@
 import {NgModule} from "@angular/core";
 import {CommonModule} from "@angular/common";
-import {DropdownConfig, DropdownModule} from "ng2-bootstrap";
+import {BsDropdownConfig, BsDropdownModule} from 'ngx-bootstrap/dropdown';
 import {FormsModule} from "@angular/forms";
 import {RouterModule, Routes} from "@angular/router";
 import {ModalModule} from "ng2-modal";
@@ -28,8 +28,8 @@ export const configMapRoutes: Routes = [
 
 @NgModule({
   imports: [
+    BsDropdownModule.forRoot(),
     CommonModule,
-    DropdownModule,
     FormsModule,
     ModalModule,
     MomentModule,
@@ -60,7 +60,7 @@ export const configMapRoutes: Routes = [
     ConfigMapsListComponent,
   ],
   providers: [
-    DropdownConfig
+    BsDropdownConfig
   ]
 })
 export class ConfigMapModule {

--- a/src/app/kubernetes/ui/configmap/list-toolbar/list-toolbar.configmap.component.html
+++ b/src/app/kubernetes/ui/configmap/list-toolbar/list-toolbar.configmap.component.html
@@ -10,11 +10,11 @@
       <div class='form-group toolbar-pf-filter search'>
         <label class='sr-only'>Name</label>
         <div class='input-group'>
-          <div class='input-group-btn' dropdown>
-            <button type='button' class='btn btn-default' aria-haspopup='true' aria-expanded='false' dropdownToggle>Name&nbsp;
+          <div class='input-group-btn dropdown' dropdown>
+            <button type='button' class='btn btn-default dropdown-toggle' aria-haspopup='true' aria-expanded='false' dropdownToggle>Name&nbsp;
               <span class='caret'></span>
             </button>
-            <ul role="menu" dropdownMenu>
+            <ul class="dropdown-menu" role="menu" *dropdownMenu>
               <li>
                 <a href='#'>Name</a>
               </li>
@@ -30,11 +30,11 @@
       <!-- Toolbar: Sort -->
 
       <div class='form-group sort'>
-        <div class='btn-group' dropdown>
-          <button type='button' class='btn btn-default' aria-haspopup='true' aria-expanded='false' dropdownToggle>Name&nbsp;
+        <div class='btn-group dropdown' dropdown>
+          <button type='button' class='btn btn-default dropdown-toggle' aria-haspopup='true' aria-expanded='false' dropdownToggle>Name&nbsp;
             <span class='caret'></span>
           </button>
-          <ul role="menu" dropdownMenu>
+          <ul class="dropdown-menu" role="menu" *dropdownMenu>
             <li>
               <a href='#'>Name</a>
             </li>

--- a/src/app/kubernetes/ui/configmap/list/list.configmap.component.html
+++ b/src/app/kubernetes/ui/configmap/list/list.configmap.component.html
@@ -6,11 +6,11 @@
         <input type='checkbox'>
       </div>
       <div class='list-view-pf-actions'>
-        <div class='pull-right dropdown-kebab-pf' dropdown>
-          <button class='btn btn-link' type='button' id='dropdownKebabRight9' aria-haspopup='true' aria-expanded='true' dropdownToggle>
+        <div class='pull-right dropdown-kebab-pf dropdown' dropdown>
+          <button class='btn btn-link dropdown-toggle' type='button' id='dropdownKebabRight9' aria-haspopup='true' aria-expanded='true' dropdownToggle>
               <span class='fa fa-ellipsis-v'></span>
             </button>
-          <ul class='dropdown-menu-right' aria-labelledby='dropdownKebabRight9' role="menu" dropdownMenu>
+          <ul class='dropdown-menu-right dropdown-menu' aria-labelledby='dropdownKebabRight9' role="menu" *dropdownMenu>
             <li>
               <a [routerLink]="[prefixPath(configmap.id), 'edit']">Edit</a>
             </li>

--- a/src/app/kubernetes/ui/deployment/deployment-routing.module.ts
+++ b/src/app/kubernetes/ui/deployment/deployment-routing.module.ts
@@ -1,6 +1,5 @@
 import {NgModule} from "@angular/core";
 import {CommonModule} from "@angular/common";
-import {DropdownConfig, DropdownModule} from "ng2-bootstrap";
 import {FormsModule} from "@angular/forms";
 import {RouterModule, Routes} from "@angular/router";
 import {ModalModule} from "ng2-modal";

--- a/src/app/kubernetes/ui/deployment/deployment.module.ts
+++ b/src/app/kubernetes/ui/deployment/deployment.module.ts
@@ -1,7 +1,7 @@
 import { DeploymentRoutingModule } from './deployment-routing.module';
 import {NgModule} from "@angular/core";
 import {CommonModule} from "@angular/common";
-import {DropdownConfig, DropdownModule} from "ng2-bootstrap";
+import {BsDropdownConfig, BsDropdownModule} from 'ngx-bootstrap/dropdown';
 import {FormsModule} from "@angular/forms";
 import {RouterModule, Routes} from "@angular/router";
 import {ModalModule} from "ng2-modal";
@@ -24,8 +24,8 @@ import {DeploymentScaleDialog} from './scale-dialog/scale-dialog.deployment.comp
 
 @NgModule({
   imports: [
+    BsDropdownModule.forRoot(),
     CommonModule,
-    DropdownModule,
     FormsModule,
     ModalModule,
     MomentModule,
@@ -59,7 +59,7 @@ import {DeploymentScaleDialog} from './scale-dialog/scale-dialog.deployment.comp
     DeploymentScaleDialog,
   ],
   providers: [
-    DropdownConfig
+    BsDropdownConfig
   ]
 })
 export class DeploymentModule {

--- a/src/app/kubernetes/ui/deployment/list-toolbar/list-toolbar.deployment.component.html
+++ b/src/app/kubernetes/ui/deployment/list-toolbar/list-toolbar.deployment.component.html
@@ -10,11 +10,11 @@
       <div class='form-group toolbar-pf-filter search'>
         <label class='sr-only'>Name</label>
         <div class='input-group'>
-          <div class='input-group-btn' dropdown>
-            <button type='button' class='btn btn-default' aria-haspopup='true' aria-expanded='false' dropdownToggle>Name&nbsp;
+          <div class='input-group-btn dropdown' dropdown>
+            <button type='button' class='btn btn-default dropdown-toggle' aria-haspopup='true' aria-expanded='false' dropdownToggle>Name&nbsp;
               <span class='caret'></span>
             </button>
-            <ul role="menu" dropdownMenu>
+            <ul class="dropdown-menu" role="menu" *dropdownMenu>
               <li>
                 <a href='#'>Name</a>
               </li>
@@ -30,11 +30,11 @@
       <!-- Toolbar: Sort -->
 
       <div class='form-group sort'>
-        <div class='btn-group' dropdown>
-          <button type='button' class='btn btn-default' aria-haspopup='true' aria-expanded='false' dropdownToggle>Name&nbsp;
+        <div class='btn-group dropdown' dropdown>
+          <button type='button' class='btn btn-default dropdown-toggle' aria-haspopup='true' aria-expanded='false' dropdownToggle>Name&nbsp;
             <span class='caret'></span>
           </button>
-          <ul role="menu" dropdownMenu>
+          <ul class="dropdown-menu" role="menu" *dropdownMenu>
             <li>
               <a href='#'>Name</a>
             </li>

--- a/src/app/kubernetes/ui/deployment/list/list.deployment.component.html
+++ b/src/app/kubernetes/ui/deployment/list/list.deployment.component.html
@@ -6,12 +6,12 @@
         <input type='checkbox'>
       </div>
       <div class='list-view-pf-actions'>
-        <div class='pull-right dropdown-kebab-pf' dropdown>
-          <button class='btn btn-link' type='button' id='dropdownKebabRight9'
+        <div class='pull-right dropdown-kebab-pf dropdown' dropdown>
+          <button class='btn btn-link dropdown-toggle' type='button' id='dropdownKebabRight9'
                   aria-haspopup='true' aria-expanded='true' dropdownToggle>
             <span class='fa fa-ellipsis-v'></span>
           </button>
-          <ul class='dropdown-menu-right' aria-labelledby='dropdownKebabRight9' role="menu" dropdownMenu>
+          <ul class='dropdown-menu-right dropdown-menu' aria-labelledby='dropdownKebabRight9' role="menu" *dropdownMenu>
             <li *ngIf="deployment.exposeUrl">
               <a target="deployment" [href]="deployment.exposeUrl"
                  title="Open this deployment in a separate browser tab">

--- a/src/app/kubernetes/ui/environment/environment-routing.module.ts
+++ b/src/app/kubernetes/ui/environment/environment-routing.module.ts
@@ -9,12 +9,10 @@ import { ConfigMapStore } from './../../store/configmap.store';
 import { NamespaceStore } from './../../store/namespace.store';
 
 import { NgModule } from '@angular/core';
-import { DropdownConfig, DropdownModule } from 'ng2-bootstrap';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { RouterModule, Routes } from '@angular/router';
 import { ModalModule } from 'ng2-modal';
-import { ToolbarModule, TreeListModule } from 'ngx-widgets';
 import { TreeModule } from 'angular2-tree-component';
 import { Fabric8CommonModule } from '../../../common/common.module';
 import { MomentModule } from 'angular2-moment';

--- a/src/app/kubernetes/ui/environment/environment.module.ts
+++ b/src/app/kubernetes/ui/environment/environment.module.ts
@@ -11,12 +11,13 @@ import { ConfigMapStore } from './../../store/configmap.store';
 import { NamespaceStore } from './../../store/namespace.store';
 
 import {NgModule} from '@angular/core';
-import {DropdownConfig, DropdownModule, TabsModule} from 'ng2-bootstrap';
+import {BsDropdownConfig, BsDropdownModule} from 'ngx-bootstrap/dropdown';
+import {TabsModule} from 'ng2-bootstrap';
 import {CommonModule} from '@angular/common';
 import {FormsModule} from '@angular/forms';
 import {RouterModule, Routes} from '@angular/router';
 import {ModalModule} from 'ng2-modal';
-import { ToolbarModule, TreeListModule, SlideOutPanelModule } from 'ngx-widgets';
+import { TreeListModule, SlideOutPanelModule } from 'ngx-widgets';
 import { TreeModule } from 'angular2-tree-component';
 import {Fabric8CommonModule} from '../../../common/common.module';
 import {MomentModule} from 'angular2-moment';
@@ -30,15 +31,14 @@ import { EnvironmentListToolbarComponent } from './list-toolbar/list-toolbar.env
 
 @NgModule({
   imports: [
+    BsDropdownModule.forRoot(),
     CommonModule,
-    DropdownModule,
     FormsModule,
     ModalModule,
     MomentModule,
     RouterModule,
     Fabric8CommonModule,
     KubernetesComponentsModule,
-    ToolbarModule,
     TreeListModule,
     TreeModule,
     TabsModule.forRoot(),
@@ -59,7 +59,7 @@ import { EnvironmentListToolbarComponent } from './list-toolbar/list-toolbar.env
     EnvironmentDetailComponent,
   ],
   providers: [
-    DropdownConfig,
+    BsDropdownConfig,
     NamespaceStore,
     ConfigMapService,
     ConfigMapStore,

--- a/src/app/kubernetes/ui/environment/list-toolbar/list-toolbar.environment.component.html
+++ b/src/app/kubernetes/ui/environment/list-toolbar/list-toolbar.environment.component.html
@@ -7,11 +7,11 @@
       <div class='form-group toolbar-pf-filter search'>
         <label class='sr-only'>Name</label>
         <div class='input-group'>
-          <div class='input-group-btn' dropdown>
-            <button type='button' class='btn btn-default' aria-haspopup='true' aria-expanded='false' dropdownToggle>Name&nbsp;
+          <div class='input-group-btn dropdown' dropdown>
+            <button type='button' class='btn btn-default dropdown-toggle' aria-haspopup='true' aria-expanded='false' dropdownToggle>Name&nbsp;
                 <span class='caret'></span>
               </button>
-            <ul role="menu" dropdownMenu>
+            <ul class="dropdown-menu" role="menu" *dropdownMenu>
               <li>
                 <a href='#'>Name</a>
               </li>
@@ -27,11 +27,11 @@
       <!-- Toolbar: Sort -->
 
       <div class='form-group sort'>
-        <div class='dropdown btn-group' dropdown>
-          <button type='button' class='btn btn-default' aria-haspopup='true' aria-expanded='false' dropdownToggle>Name&nbsp;
+        <div class='dropdown btn-group dropdown' dropdown>
+          <button type='button' class='btn btn-default dropdown-toggle' aria-haspopup='true' aria-expanded='false' dropdownToggle>Name&nbsp;
               <span class='caret'></span>
             </button>
-          <ul role="menu" dropdownMenu>
+          <ul class="dropdown-menu" role="menu" *dropdownMenu>
             <li>
               <a href='#'>Name</a>
             </li>

--- a/src/app/kubernetes/ui/event/event.module.ts
+++ b/src/app/kubernetes/ui/event/event.module.ts
@@ -1,6 +1,6 @@
 import {NgModule} from "@angular/core";
 import {CommonModule} from "@angular/common";
-import {DropdownConfig, DropdownModule} from "ng2-bootstrap";
+import {BsDropdownConfig, BsDropdownModule} from 'ngx-bootstrap/dropdown';
 import {FormsModule} from "@angular/forms";
 import {RouterModule, Routes} from "@angular/router";
 import {ModalModule} from "ng2-modal";
@@ -22,8 +22,8 @@ export const eventRoutes: Routes = [
 
 @NgModule({
   imports: [
+    BsDropdownModule.forRoot(),
     CommonModule,
-    DropdownModule,
     FormsModule,
     ModalModule,
     MomentModule,
@@ -45,7 +45,7 @@ export const eventRoutes: Routes = [
     EventsListComponent,
   ],
   providers: [
-    DropdownConfig
+    BsDropdownConfig
   ]
 })
 export class EventModule {

--- a/src/app/kubernetes/ui/event/list-toolbar/list-toolbar.event.component.html
+++ b/src/app/kubernetes/ui/event/list-toolbar/list-toolbar.event.component.html
@@ -10,11 +10,11 @@
       <div class='form-group toolbar-pf-filter search'>
         <label class='sr-only'>Name</label>
         <div class='input-group'>
-          <div class='input-group-btn' dropdown>
-            <button type='button' class='btn btn-default' aria-haspopup='true' aria-expanded='false' dropdownToggle>Name&nbsp;
+          <div class='input-group-btn dropdown' dropdown>
+            <button type='button' class='btn btn-default dropdown-toggle' aria-haspopup='true' aria-expanded='false' dropdownToggle>Name&nbsp;
               <span class='caret'></span>
             </button>
-            <ul role="menu" dropdownMenu>
+            <ul class="dropdown-menu" role="menu" *dropdownMenu>
               <li>
                 <a href='#'>Name</a>
               </li>
@@ -30,11 +30,11 @@
       <!-- Toolbar: Sort -->
 
       <div class='form-group sort'>
-        <div class='btn-group' dropdown>
-          <button type='button' class='btn btn-default' aria-haspopup='true' aria-expanded='false' dropdownToggle>Name&nbsp;
+        <div class='btn-group dropdown' dropdown>
+          <button type='button' class='btn btn-default dropdown-toggle' aria-haspopup='true' aria-expanded='false' dropdownToggle>Name&nbsp;
             <span class='caret'></span>
           </button>
-          <ul role="menu" dropdownMenu>
+          <ul class="dropdown-menu" role="menu" *dropdownMenu>
             <li>
               <a href='#'>Name</a>
             </li>

--- a/src/app/kubernetes/ui/event/list/list.event.component.html
+++ b/src/app/kubernetes/ui/event/list/list.event.component.html
@@ -6,11 +6,11 @@
         <input type='checkbox'>
       </div>
       <div class='list-view-pf-actions'>
-        <div class='pull-right dropdown-kebab-pf' dropdown>
-          <button class='btn btn-link' type='button' id='dropdownKebabRight9' aria-haspopup='true' aria-expanded='true' dropdownToggle>
+        <div class='pull-right dropdown-kebab-pf dropdown' dropdown>
+          <button class='btn btn-link dropdown-toggle' type='button' id='dropdownKebabRight9' aria-haspopup='true' aria-expanded='true' dropdownToggle>
               <span class='fa fa-ellipsis-v'></span>
             </button>
-          <ul class='dropdown-menu-right' aria-labelledby='dropdownKebabRight9' role="menu" dropdownMenu>
+          <ul class='dropdown-menu-right dropdown-menu' aria-labelledby='dropdownKebabRight9' role="menu" *dropdownMenu>
 <!--
             <li>
               <a [routerLink]="[prefixPath(event.id), 'edit']">Edit</a>

--- a/src/app/kubernetes/ui/namespace/list-toolbar/list-toolbar.namespace.component.html
+++ b/src/app/kubernetes/ui/namespace/list-toolbar/list-toolbar.namespace.component.html
@@ -7,11 +7,11 @@
       <div class='form-group toolbar-pf-filter search'>
         <label class='sr-only'>Name</label>
         <div class='input-group'>
-          <div class='input-group-btn' dropdown>
-            <button type='button' class='btn btn-default' aria-haspopup='true' aria-expanded='false' dropdownToggle>Name&nbsp;
+          <div class='input-group-btn dropdown' dropdown>
+            <button type='button' class='btn btn-default dropdown-toggle' aria-haspopup='true' aria-expanded='false' dropdownToggle>Name&nbsp;
                 <span class='caret'></span>
               </button>
-            <ul role="menu" dropdownMenu>
+            <ul class="dropdown-menu" role="menu" *dropdownMenu>
               <li>
                 <a href='#'>Name</a>
               </li>
@@ -27,11 +27,11 @@
       <!-- Toolbar: Sort -->
 
       <div class='form-group sort'>
-        <div class='btn-group' dropdown>
-          <button type='button' class='btn btn-default' aria-haspopup='true' aria-expanded='false' dropdownToggle>Name&nbsp;
+        <div class='btn-group dropdown' dropdown>
+          <button type='button' class='btn btn-default dropdown-toggle' aria-haspopup='true' aria-expanded='false' dropdownToggle>Name&nbsp;
               <span class='caret'></span>
             </button>
-          <ul role="menu" dropdownMenu>
+          <ul class="dropdown-menu" role="menu" *dropdownMenu>
             <li>
               <a href='#'>Name</a>
             </li>

--- a/src/app/kubernetes/ui/namespace/list/list.namespace.component.html
+++ b/src/app/kubernetes/ui/namespace/list/list.namespace.component.html
@@ -6,11 +6,11 @@
         <input type='checkbox'>
       </div>
       <div class='list-view-pf-actions'>
-        <div class='pull-right dropdown-kebab-pf' dropdown>
-          <button class='btn btn-link' type='button' id='dropdownKebabRight9' aria-haspopup='true' aria-expanded='true' dropdownToggle>
+        <div class='pull-right dropdown-kebab-pf dropdown' dropdown>
+          <button class='btn btn-link dropdown-toggle' type='button' id='dropdownKebabRight9' aria-haspopup='true' aria-expanded='true' dropdownToggle>
               <span class='fa fa-ellipsis-v'></span>
             </button>
-          <ul class='dropdown-menu-right' aria-labelledby='dropdownKebabRight9' role="menu" dropdownMenu>
+          <ul class='dropdown-menu-right dropdown-menu' aria-labelledby='dropdownKebabRight9' role="menu" *dropdownMenu>
             <li>
               <a [routerLink]="[namespace.id]">View Details</a>
             </li>

--- a/src/app/kubernetes/ui/namespace/namespace.module.ts
+++ b/src/app/kubernetes/ui/namespace/namespace.module.ts
@@ -1,6 +1,6 @@
 import {NgModule} from "@angular/core";
 import {CommonModule} from "@angular/common";
-import {DropdownConfig, DropdownModule} from "ng2-bootstrap";
+import {BsDropdownConfig, BsDropdownModule} from 'ngx-bootstrap/dropdown';
 import {FormsModule} from "@angular/forms";
 import {RouterModule, Routes} from "@angular/router";
 import {ModalModule} from "ng2-modal";
@@ -28,8 +28,8 @@ const routes: Routes = [
 
 @NgModule({
   imports: [
+    BsDropdownModule.forRoot(),
     CommonModule,
-    DropdownModule,
     FormsModule,
     ModalModule,
     MomentModule,
@@ -60,7 +60,7 @@ const routes: Routes = [
     ModalModule,
   ],
   providers: [
-    DropdownConfig
+    BsDropdownConfig
   ]
 })
 export class NamespaceModule {

--- a/src/app/kubernetes/ui/pipeline/full-history-toolbar/full-history-toolbar.pipeline.component.html
+++ b/src/app/kubernetes/ui/pipeline/full-history-toolbar/full-history-toolbar.pipeline.component.html
@@ -12,11 +12,11 @@
       <div class='form-group toolbar-pf-filter search'>
         <label class='sr-only'>Name</label>
         <div class='input-group'>
-          <div class='input-group-btn' dropdown>
-            <button type='button' class='btn btn-default' aria-haspopup='true' aria-expanded='false' dropdownToggle>Name&nbsp;
+          <div class='input-group-btn dropdown' dropdown>
+            <button type='button' class='btn btn-default dropdown-toggle' aria-haspopup='true' aria-expanded='false' dropdownToggle>Name&nbsp;
               <span class='caret'></span>
             </button>
-            <ul role="menu" dropdownMenu>
+            <ul class="dropdown-menu" role="menu" *dropdownMenu>
               <li>
                 <a href='#'>Name</a>
               </li>
@@ -32,11 +32,11 @@
       <!-- Toolbar: Sort -->
 
       <div class='form-group sort'>
-        <div class='btn-group' dropdown>
-          <button type='button' class='btn btn-default' aria-haspopup='true' aria-expanded='false' dropdownToggle>Name&nbsp;
+        <div class='btn-group dropdown' dropdown>
+          <button type='button' class='btn btn-default dropdown-toggle' aria-haspopup='true' aria-expanded='false' dropdownToggle>Name&nbsp;
             <span class='caret'></span>
           </button>
-          <ul role="menu" dropdownMenu>
+          <ul class="dropdown-menu" role="menu" *dropdownMenu>
             <li>
               <a href='#'>Name</a>
             </li>

--- a/src/app/kubernetes/ui/pipeline/full-history/full-history.pipeline.component.html
+++ b/src/app/kubernetes/ui/pipeline/full-history/full-history.pipeline.component.html
@@ -15,12 +15,12 @@
               </small>
             </h3>
 
-            <div class='pull-right dropdown-kebab-pf' dropdown>
-              <button class='btn btn-link' type='button' id='dropdownKebabRight9'
+            <div class='pull-right dropdown-kebab-pf dropdown' dropdown>
+              <button class='btn btn-link dropdown-toggle' type='button' id='dropdownKebabRight9'
                       aria-haspopup='true' aria-expanded='true' dropdownToggle>
                 <span class='fa fa-ellipsis-v'></span>
               </button>
-              <ul class='dropdown-menu dropdown-menu-right' aria-labelledby='dropdownKebabRight9' role="menu" dropdownMenu>
+              <ul class='dropdown-menu dropdown-menu-right dropdown-menu' aria-labelledby='dropdownKebabRight9' role="menu" *dropdownMenu>
                 <li *ngIf="pipeline.lastBuildPath">
                   <a routerLink="{{pipeline.lastBuildPath}}" title="view last build">
                     View last build

--- a/src/app/kubernetes/ui/pipeline/history/history.pipeline.component.html
+++ b/src/app/kubernetes/ui/pipeline/history/history.pipeline.component.html
@@ -16,12 +16,12 @@
               </small>
             </h3>
 
-            <div class='pull-right dropdown-kebab-pf' dropdown>
-              <button class='btn btn-link' type='button' id='dropdownKebabRight9'
+            <div class='pull-right dropdown-kebab-pf dropdown' dropdown>
+              <button class='btn btn-link dropdown-toggle' type='button' id='dropdownKebabRight9'
                       aria-haspopup='true' aria-expanded='true' dropdownToggle>
                 <span class='fa fa-ellipsis-v'></span>
               </button>
-              <ul class='dropdown-menu-right' aria-labelledby='dropdownKebabRight9' role="menu" dropdownMenu>
+              <ul class='dropdown-menu-right dropdown-menu' aria-labelledby='dropdownKebabRight9' role="menu" *dropdownMenu>
                 <li *ngIf="pipeline.lastBuildPath">
                   <a routerLink="{{pipeline.lastBuildPath}}" title="view last build">
                     View last build

--- a/src/app/kubernetes/ui/pipeline/list/list.pipeline.component.html
+++ b/src/app/kubernetes/ui/pipeline/list/list.pipeline.component.html
@@ -16,12 +16,12 @@
               <small>created {{pipeline.creationTimestamp | amTimeAgo}}</small>
             </h3>
 
-            <div class='pull-right dropdown-kebab-pf' dropdown>
-              <button class='btn btn-link' type='button' id='dropdownKebabRight9'
+            <div class='pull-right dropdown-kebab-pf dropdown' dropdown>
+              <button class='btn btn-link dropdown-toggle' type='button' id='dropdownKebabRight9'
                       aria-haspopup='true' aria-expanded='true' dropdownToggle>
                 <span class='fa fa-ellipsis-v'></span>
               </button>
-              <ul class='dropdown-menu-right' aria-labelledby='dropdownKebabRight9' role="menu" dropdownMenu>
+              <ul class='dropdown-menu-right dropdown-menu' aria-labelledby='dropdownKebabRight9' role="menu" *dropdownMenu>
                 <li>
                   <a (click)="startBuild(pipeline)" title="Start this Pipeline">Start Pipeline</a>
                 </li>

--- a/src/app/kubernetes/ui/pipeline/pipeline-full-history.module.ts
+++ b/src/app/kubernetes/ui/pipeline/pipeline-full-history.module.ts
@@ -1,6 +1,6 @@
 import {NgModule} from "@angular/core";
 import {CommonModule} from "@angular/common";
-import {DropdownConfig, DropdownModule} from "ng2-bootstrap";
+import {BsDropdownConfig, BsDropdownModule} from 'ngx-bootstrap/dropdown';
 import {FormsModule} from "@angular/forms";
 import {RouterModule, Routes} from "@angular/router";
 import {ModalModule} from "ng2-modal";
@@ -17,8 +17,8 @@ const routes: Routes = [
 
 @NgModule({
   imports: [
+    BsDropdownModule.forRoot(),
     CommonModule,
-    DropdownModule,
     FormsModule,
     ModalModule,
     MomentModule,
@@ -35,7 +35,7 @@ const routes: Routes = [
   exports: [
   ],
   providers: [
-    DropdownConfig
+    BsDropdownConfig
   ]
 })
 export class PipelineFullHistoryModule {

--- a/src/app/kubernetes/ui/pipeline/pipeline.module.ts
+++ b/src/app/kubernetes/ui/pipeline/pipeline.module.ts
@@ -1,7 +1,7 @@
 import { StageTimePipe } from './build-stage-view/stage-time.pipe';
 import {NgModule} from "@angular/core";
 import {CommonModule} from "@angular/common";
-import {DropdownConfig, DropdownModule} from "ng2-bootstrap";
+import {BsDropdownConfig, BsDropdownModule} from 'ngx-bootstrap/dropdown';
 import {FormsModule} from "@angular/forms";
 import {RouterModule, Routes} from "@angular/router";
 import {ModalModule} from "ng2-modal";
@@ -34,8 +34,8 @@ const routes: Routes = [
 
 @NgModule({
   imports: [
+    BsDropdownModule.forRoot(),
     CommonModule,
-    DropdownModule,
     FormsModule,
     ModalModule,
     MomentModule,
@@ -70,7 +70,7 @@ const routes: Routes = [
     PipelinesListToolbarComponent,
   ],
   providers: [
-    DropdownConfig
+    BsDropdownConfig
   ]
 })
 export class PipelineModule {

--- a/src/app/kubernetes/ui/pod/list-toolbar/list-toolbar.pod.component.html
+++ b/src/app/kubernetes/ui/pod/list-toolbar/list-toolbar.pod.component.html
@@ -10,11 +10,11 @@
       <div class='form-group toolbar-pf-filter search'>
         <label class='sr-only'>Name</label>
         <div class='input-group'>
-          <div class='input-group-btn' dropdown>
-            <button type='button' class='btn btn-default' aria-haspopup='true' aria-expanded='false' dropdownToggle>Name&nbsp;
+          <div class='input-group-btn dropdown' dropdown>
+            <button type='button' class='btn btn-default dropdown-toggle' aria-haspopup='true' aria-expanded='false' dropdownToggle>Name&nbsp;
               <span class='caret'></span>
             </button>
-            <ul role="menu" dropdownMenu>
+            <ul class="dropdown-menu" role="menu" *dropdownMenu>
               <li>
                 <a href='#'>Name</a>
               </li>
@@ -30,11 +30,11 @@
       <!-- Toolbar: Sort -->
 
       <div class='form-group sort'>
-        <div class='btn-group' dropdown>
-          <button type='button' class='btn btn-default' aria-haspopup='true' aria-expanded='false' dropdownToggle>Name&nbsp;
+        <div class='btn-group dropdown' dropdown>
+          <button type='button' class='btn btn-default dropdown-toggle' aria-haspopup='true' aria-expanded='false' dropdownToggle>Name&nbsp;
             <span class='caret'></span>
           </button>
-          <ul role="menu" dropdownMenu>
+          <ul class="dropdown-menu" role="menu" *dropdownMenu>
             <li>
               <a href='#'>Name</a>
             </li>

--- a/src/app/kubernetes/ui/pod/list/list.pod.component.html
+++ b/src/app/kubernetes/ui/pod/list/list.pod.component.html
@@ -6,11 +6,11 @@
         <input type='checkbox'>
       </div>
       <div class='list-view-pf-actions'>
-        <div class='pull-right dropdown-kebab-pf' dropdown>
-          <button class='btn btn-link' type='button' id='dropdownKebabRight9' aria-haspopup='true' aria-expanded='true' dropdownToggle>
+        <div class='pull-right dropdown-kebab-pf dropdown' dropdown>
+          <button class='btn btn-link dropdown-toggle' type='button' id='dropdownKebabRight9' aria-haspopup='true' aria-expanded='true' dropdownToggle>
               <span class='fa fa-ellipsis-v'></span>
             </button>
-          <ul class='dropdown-menu-right' aria-labelledby='dropdownKebabRight9' role="menu" dropdownMenu>
+          <ul class='dropdown-menu-right dropdown-menu' aria-labelledby='dropdownKebabRight9' role="menu" *dropdownMenu>
             <li *ngIf="consoleLogsUrl(pod)">
               <a [href]="consoleLogsUrl(pod)" target="openshift">View Logs</a>
             </li>

--- a/src/app/kubernetes/ui/pod/pod.module.ts
+++ b/src/app/kubernetes/ui/pod/pod.module.ts
@@ -1,6 +1,6 @@
 import {NgModule} from "@angular/core";
 import {CommonModule} from "@angular/common";
-import {DropdownConfig, DropdownModule} from "ng2-bootstrap";
+import {BsDropdownConfig, BsDropdownModule} from 'ngx-bootstrap/dropdown';
 import {FormsModule} from "@angular/forms";
 import {RouterModule, Routes} from "@angular/router";
 import {ModalModule} from "ng2-modal";
@@ -28,8 +28,8 @@ export const podRoutes: Routes = [
 
 @NgModule({
   imports: [
+    BsDropdownModule.forRoot(),
     CommonModule,
-    DropdownModule,
     FormsModule,
     ModalModule,
     MomentModule,
@@ -60,7 +60,7 @@ export const podRoutes: Routes = [
     PodsListComponent,
   ],
   providers: [
-    DropdownConfig
+    BsDropdownConfig
   ]
 })
 export class PodModule {

--- a/src/app/kubernetes/ui/replicaset/list-toolbar/list-toolbar.replicaset.component.html
+++ b/src/app/kubernetes/ui/replicaset/list-toolbar/list-toolbar.replicaset.component.html
@@ -10,11 +10,11 @@
       <div class='form-group toolbar-pf-filter search'>
         <label class='sr-only'>Name</label>
         <div class='input-group'>
-          <div class='input-group-btn' dropdown>
-            <button type='button' class='btn btn-default' aria-haspopup='true' aria-expanded='false' dropdownToggle>Name&nbsp;
+          <div class='input-group-btn dropdown' dropdown>
+            <button type='button' class='btn btn-default dropdown-toggle' aria-haspopup='true' aria-expanded='false' dropdownToggle>Name&nbsp;
               <span class='caret'></span>
             </button>
-            <ul role="menu" dropdownMenu>
+            <ul class="dropdown-menu" role="menu" *dropdownMenu>
               <li>
                 <a href='#'>Name</a>
               </li>
@@ -30,11 +30,11 @@
       <!-- Toolbar: Sort -->
 
       <div class='form-group sort'>
-        <div class='btn-group' dropdown>
-          <button type='button' class='btn btn-default' aria-haspopup='true' aria-expanded='false' dropdownToggle>Name&nbsp;
+        <div class='btn-group dropdown' dropdown>
+          <button type='button' class='btn btn-default dropdown-toggle' aria-haspopup='true' aria-expanded='false' dropdownToggle>Name&nbsp;
             <span class='caret'></span>
           </button>
-          <ul role="menu" dropdownMenu>
+          <ul class="dropdown-menu" role="menu" *dropdownMenu>
             <li>
               <a href='#'>Name</a>
             </li>

--- a/src/app/kubernetes/ui/replicaset/list/list.replicaset.component.html
+++ b/src/app/kubernetes/ui/replicaset/list/list.replicaset.component.html
@@ -6,11 +6,11 @@
         <input type='checkbox'>
       </div>
       <div class='list-view-pf-actions'>
-        <div class='pull-right dropdown-kebab-pf' dropdown>
-          <button class='btn btn-link' type='button' id='dropdownKebabRight9' aria-haspopup='true' aria-expanded='true' dropdownToggle>
+        <div class='pull-right dropdown-kebab-pf dropdown' dropdown>
+          <button class='btn btn-link dropdown-toggle' type='button' id='dropdownKebabRight9' aria-haspopup='true' aria-expanded='true' dropdownToggle>
               <span class='fa fa-ellipsis-v'></span>
             </button>
-          <ul class='dropdown-menu-right' aria-labelledby='dropdownKebabRight9' role="menu" dropdownMenu>
+          <ul class='dropdown-menu-right dropdown-menu' aria-labelledby='dropdownKebabRight9' role="menu" *dropdownMenu>
             <li *ngIf="replicaset.exposeUrl">
               <a target="replicaset" [href]="replicaset.exposeUrl"
                  title="Open this replicaset in a separate browser tab">

--- a/src/app/kubernetes/ui/replicaset/replicaset.module.ts
+++ b/src/app/kubernetes/ui/replicaset/replicaset.module.ts
@@ -1,6 +1,6 @@
 import {NgModule} from "@angular/core";
 import {CommonModule} from "@angular/common";
-import {DropdownConfig, DropdownModule} from "ng2-bootstrap";
+import {BsDropdownConfig, BsDropdownModule} from 'ngx-bootstrap/dropdown';
 import {FormsModule} from "@angular/forms";
 import {RouterModule, Routes} from "@angular/router";
 import {ModalModule} from "ng2-modal";
@@ -29,8 +29,8 @@ export const replicaSetRoutes: Routes = [
 
 @NgModule({
   imports: [
+    BsDropdownModule.forRoot(),
     CommonModule,
-    DropdownModule,
     FormsModule,
     ModalModule,
     MomentModule,
@@ -62,7 +62,7 @@ export const replicaSetRoutes: Routes = [
     ReplicaSetsListComponent,
   ],
   providers: [
-    DropdownConfig
+    BsDropdownConfig
   ]
 })
 export class ReplicaSetModule {

--- a/src/app/kubernetes/ui/service/list-toolbar/list-toolbar.service.component.html
+++ b/src/app/kubernetes/ui/service/list-toolbar/list-toolbar.service.component.html
@@ -10,11 +10,11 @@
       <div class='form-group toolbar-pf-filter search'>
         <label class='sr-only'>Name</label>
         <div class='input-group'>
-          <div class='input-group-btn' dropdown>
-            <button type='button' class='btn btn-default' aria-haspopup='true' aria-expanded='false' dropdownToggle>Name&nbsp;
+          <div class='input-group-btn dropdown' dropdown>
+            <button type='button' class='btn btn-default dropdown-toggle' aria-haspopup='true' aria-expanded='false' dropdownToggle>Name&nbsp;
               <span class='caret'></span>
             </button>
-            <ul role="menu" dropdownMenu>
+            <ul class="dropdown-menu" role="menu" *dropdownMenu>
               <li>
                 <a href='#'>Name</a>
               </li>
@@ -30,11 +30,11 @@
       <!-- Toolbar: Sort -->
 
       <div class='form-group sort'>
-        <div class='btn-group' dropdown>
-          <button type='button' class='btn btn-default' aria-haspopup='true' aria-expanded='false' dropdownToggle>Name&nbsp;
+        <div class='btn-group dropdown' dropdown>
+          <button type='button' class='btn btn-default dropdown-toggle' aria-haspopup='true' aria-expanded='false' dropdownToggle>Name&nbsp;
             <span class='caret'></span>
           </button>
-          <ul role="menu" dropdownMenu>
+          <ul class="dropdown-menu" role="menu" *dropdownMenu>
             <li>
               <a href='#'>Name</a>
             </li>

--- a/src/app/kubernetes/ui/service/list/list.service.component.html
+++ b/src/app/kubernetes/ui/service/list/list.service.component.html
@@ -6,11 +6,11 @@
         <input type='checkbox'>
       </div>
       <div class='list-view-pf-actions'>
-        <div class='pull-right dropdown-kebab-pf' dropdown>
-          <button class='btn btn-link' type='button' id='dropdownKebabRight9' aria-haspopup='true' aria-expanded='true' dropdownToggle>
+        <div class='pull-right dropdown-kebab-pf dropdown' dropdown>
+          <button class='btn btn-link dropdown-toggle' type='button' id='dropdownKebabRight9' aria-haspopup='true' aria-expanded='true' dropdownToggle>
               <span class='fa fa-ellipsis-v'></span>
             </button>
-          <ul class='dropdown-menu-right' aria-labelledby='dropdownKebabRight9' role="menu" dropdownMenu>
+          <ul class='dropdown-menu-right dropdown-menu' aria-labelledby='dropdownKebabRight9' role="menu" *dropdownMenu>
             <li *ngIf="service.openShiftConsoleUrl">
               <a [href]="service.openShiftConsoleUrl" target="openshift" title="View this Service in the OpenShift Console">OpenShift Console</a>
             </li>

--- a/src/app/kubernetes/ui/service/service.module.ts
+++ b/src/app/kubernetes/ui/service/service.module.ts
@@ -1,6 +1,6 @@
 import {NgModule} from "@angular/core";
 import {CommonModule} from "@angular/common";
-import {DropdownConfig, DropdownModule} from "ng2-bootstrap";
+import {BsDropdownConfig, BsDropdownModule} from 'ngx-bootstrap/dropdown';
 import {FormsModule} from "@angular/forms";
 import {RouterModule, Routes} from "@angular/router";
 import {ModalModule} from "ng2-modal";
@@ -28,8 +28,8 @@ export const serviceRoutes: Routes = [
 
 @NgModule({
   imports: [
+    BsDropdownModule.forRoot(),
     CommonModule,
-    DropdownModule,
     FormsModule,
     ModalModule,
     MomentModule,
@@ -60,7 +60,7 @@ export const serviceRoutes: Routes = [
     ServicesListComponent,
   ],
   providers: [
-    DropdownConfig
+    BsDropdownConfig
   ]
 })
 export class ServiceModule {

--- a/src/app/kubernetes/ui/space/list-toolbar/list-toolbar.space.component.html
+++ b/src/app/kubernetes/ui/space/list-toolbar/list-toolbar.space.component.html
@@ -7,11 +7,11 @@
       <div class='form-group toolbar-pf-filter search'>
         <label class='sr-only'>Name</label>
         <div class='input-group'>
-          <div class='input-group-btn' dropdown>
-            <button type='button' class='btn btn-default' aria-haspopup='true' aria-expanded='false' dropdownToggle>Name&nbsp;
+          <div class='input-group-btn dropdown' dropdown>
+            <button type='button' class='btn btn-default dropdown-toggle' aria-haspopup='true' aria-expanded='false' dropdownToggle>Name&nbsp;
                 <span class='caret'></span>
               </button>
-            <ul role="menu" dropdownMenu>
+            <ul class="dropdown-menu" role="menu" *dropdownMenu>
               <li>
                 <a href='#'>Name</a>
               </li>
@@ -27,11 +27,11 @@
       <!-- Toolbar: Sort -->
 
       <div class='form-group sort'>
-        <div class='dropdown btn-group' dropdown>
-          <button type='button' class='btn btn-default' aria-haspopup='true' aria-expanded='false' dropdownToggle>Name&nbsp;
+        <div class='dropdown btn-group dropdown' dropdown>
+          <button type='button' class='btn btn-default dropdown-toggle' aria-haspopup='true' aria-expanded='false' dropdownToggle>Name&nbsp;
               <span class='caret'></span>
             </button>
-          <ul role="menu" dropdownMenu>
+          <ul class="dropdown-menu" role="menu" *dropdownMenu>
             <li>
               <a href='#'>Name</a>
             </li>

--- a/src/app/kubernetes/ui/space/list/list.space.component.html
+++ b/src/app/kubernetes/ui/space/list/list.space.component.html
@@ -6,11 +6,11 @@
         <input type='checkbox'>
       </div>
       <div class='list-view-pf-actions'>
-        <div class='pull-right dropdown-kebab-pf' dropdown>
-          <button class='btn btn-link' type='button' id='dropdownKebabRight9' aria-haspopup='true' aria-expanded='true' dropdownToggle>
+        <div class='pull-right dropdown-kebab-pf dropdown' dropdown>
+          <button class='btn btn-link dropdown-toggle' type='button' id='dropdownKebabRight9' aria-haspopup='true' aria-expanded='true' dropdownToggle>
               <span class='fa fa-ellipsis-v'></span>
             </button>
-          <ul class='dropdown-menu-right' aria-labelledby='dropdownKebabRight9' role="menu" dropdownMenu>
+          <ul class='dropdown-menu-right dropdown-menu' aria-labelledby='dropdownKebabRight9' role="menu" *dropdownMenu>
             <li>
               <a [routerLink]="[space.id]">View Details</a>
             </li>

--- a/src/app/kubernetes/ui/space/space.module.ts
+++ b/src/app/kubernetes/ui/space/space.module.ts
@@ -1,5 +1,5 @@
 import {NgModule} from "@angular/core";
-import {DropdownConfig, DropdownModule} from "ng2-bootstrap";
+import {BsDropdownConfig, BsDropdownModule} from 'ngx-bootstrap/dropdown';
 import {CommonModule} from "@angular/common";
 import {FormsModule} from "@angular/forms";
 import {RouterModule, Routes} from "@angular/router";
@@ -34,8 +34,8 @@ const routes: Routes = [
 
 @NgModule({
   imports: [
+    BsDropdownModule.forRoot(),
     CommonModule,
-    DropdownModule,
     FormsModule,
     ModalModule,
     MomentModule,
@@ -59,7 +59,7 @@ const routes: Routes = [
     SpaceDeleteDialog,
   ],
   providers: [
-    DropdownConfig,
+    BsDropdownConfig,
     SpaceStore,
     NamespaceStore,
     ConfigMapService,

--- a/src/app/kubernetes/ui/status/status-list.module.ts
+++ b/src/app/kubernetes/ui/status/status-list.module.ts
@@ -1,5 +1,5 @@
 import {NgModule} from "@angular/core";
-import {DropdownModule} from "ng2-bootstrap";
+import {BsDropdownConfig, BsDropdownModule} from 'ngx-bootstrap/dropdown';
 import {CommonModule} from "@angular/common";
 import {FormsModule} from "@angular/forms";
 import {RouterModule} from "@angular/router";
@@ -15,8 +15,8 @@ import {StatusInfoComponent} from "./status-info-component";
 
 @NgModule({
   imports: [
+    BsDropdownModule.forRoot(),
     CommonModule,
-    DropdownModule,
     FormsModule,
     ModalModule,
     MomentModule,
@@ -29,6 +29,7 @@ import {StatusInfoComponent} from "./status-info-component";
     StatusListComponent,
   ],
   providers: [
+    BsDropdownConfig,
     SpaceStore,
     NamespaceStore,
   ],


### PR DESCRIPTION
This PR updates the runtime console to use the latest dropdown from ngx-bootstrap, which platform is now using for compatibility with patternfly-ng.

Platform PR: https://github.com/fabric8-ui/fabric8-ui/pull/1738
Planner PR: https://github.com/fabric8-ui/fabric8-planner/pull/2075